### PR TITLE
Be/feat/purchase

### DIFF
--- a/backend/src/main/java/com/ll/readycode/api/categories/controller/CategoryController.java
+++ b/backend/src/main/java/com/ll/readycode/api/categories/controller/CategoryController.java
@@ -5,13 +5,15 @@ import com.ll.readycode.api.categories.dto.response.CategoryResponse;
 import com.ll.readycode.domain.categories.service.CategoryService;
 import com.ll.readycode.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/categories")
+@Tag(name = "카테고리 API", description = "카테고리 생성, 수정, 삭제 및 조회 API")
+@RequestMapping("/api/categories")
 @RequiredArgsConstructor
 @RestController
 public class CategoryController {
@@ -32,7 +34,7 @@ public class CategoryController {
     return ResponseEntity.ok(SuccessResponse.of("카테고리를 생성했습니다.", response));
   }
 
-  @Operation(summary = "카테고리를 수정합니다.", description = "카테고리 ID를 기준으로 수정합니다.")
+  @Operation(summary = "카테고리를 수정", description = "카테고리 ID를 기준으로 수정합니다.")
   @PatchMapping("/{categoriesId}")
   public ResponseEntity<SuccessResponse<CategoryResponse>> updateCategory(
       @PathVariable Long categoriesId, @RequestBody @Valid CategoryRequest request) {
@@ -40,7 +42,7 @@ public class CategoryController {
     return ResponseEntity.ok(SuccessResponse.of("카테고리를 수정했습니다.", response));
   }
 
-  @Operation(summary = "카테고리를 삭제합니다.", description = "카테고리를 ID를 기준으로 삭제합니다.")
+  @Operation(summary = "카테고리를 삭제", description = "카테고리를 ID를 기준으로 삭제합니다.")
   @DeleteMapping("/{categoriesId}")
   public ResponseEntity<SuccessResponse<Void>> deleteCategory(@PathVariable Long categoriesId) {
     categoryService.deleteCategory(categoriesId);

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -58,8 +58,9 @@ public class TemplateController {
   @Operation(summary = "템플릿 생성", description = "템플릿을 생성합니다.")
   @PostMapping
   public ResponseEntity<SuccessResponse<TemplateResponse>> createTemplate(
-      @Valid @RequestBody TemplateCreateRequest request) {
-    Template template = templateService.create(request);
+      @Valid @RequestBody TemplateCreateRequest request,
+      @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    Template template = templateService.create(request, userPrincipal.getUserProfile());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.of("게시물이 성공적으로 생성되었습니다.", TemplateResponse.of(template)));
   }

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -11,6 +11,7 @@ import com.ll.readycode.domain.templates.templates.service.TemplateService;
 import com.ll.readycode.global.common.auth.user.UserPrincipal;
 import com.ll.readycode.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/templates")
+@Tag(name = "템플릿 API", description = "템플릿 조회, 생성, 수정, 삭제 등의 기능을 제공합니다.")
+@RequestMapping("/api/templates")
 @RequiredArgsConstructor
 @RestController
 public class TemplateController {

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -5,8 +5,10 @@ import com.ll.readycode.api.templates.dto.request.TemplateUpdateRequest;
 import com.ll.readycode.api.templates.dto.response.TemplateDetailResponse;
 import com.ll.readycode.api.templates.dto.response.TemplateResponse;
 import com.ll.readycode.api.templates.dto.response.TemplateScrollResponse;
+import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.service.TemplateService;
+import com.ll.readycode.global.common.auth.user.UserPrincipal;
 import com.ll.readycode.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/templates")
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class TemplateController {
   private final TemplateService templateService;
+  private final TemplatePurchaseService templatePurchaseService;
 
   @Operation(summary = "템플릿 목록 조회", description = "템플릿을 최신순 기준으로 커서 기반 페이징 방식으로 조회합니다.")
   @GetMapping
@@ -36,10 +40,19 @@ public class TemplateController {
   @Operation(summary = "템플릿 상세 조회", description = "템플릿 ID를 기준으로 상세 정보를 조회합니다.")
   @GetMapping("/{templatesId}")
   public ResponseEntity<SuccessResponse<TemplateDetailResponse>> detailsTemplate(
-      @PathVariable Long templatesId) {
-    Template template = templateService.findTemplateById(templatesId);
-    return ResponseEntity.ok(
-        SuccessResponse.of("성공적으로 게시물 상세 정보를 조회했습니다.", TemplateDetailResponse.of(template)));
+      @PathVariable Long templateId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    Template template = templateService.findTemplateById(templateId);
+
+    boolean purchased = false;
+    if (userPrincipal != null) {
+      purchased =
+          templatePurchaseService.existsByBuyerIdAndTemplateId(
+              userPrincipal.getUserProfile().getId(), templateId);
+    }
+
+    TemplateDetailResponse response = TemplateDetailResponse.of(template, purchased);
+
+    return ResponseEntity.ok(SuccessResponse.of("성공적으로 템플릿 상세 정보를 조회했습니다.", response));
   }
 
   @Operation(summary = "템플릿 생성", description = "템플릿을 생성합니다.")

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateDownloadController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateDownloadController.java
@@ -1,0 +1,14 @@
+package com.ll.readycode.api.templates.controller;
+
+import com.ll.readycode.domain.templates.downloads.service.TemplateDownloadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/downloads")
+public class TemplateDownloadController {
+
+  public final TemplateDownloadService templateDownloadService;
+}

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
@@ -1,7 +1,15 @@
 package com.ll.readycode.api.templates.controller;
 
 import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
+import com.ll.readycode.global.common.auth.user.UserPrincipal;
+import com.ll.readycode.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class TemplatePurchaseController {
 
   private final TemplatePurchaseService templatePurchaseService;
+
+  @PostMapping("/{templateId}")
+  @Operation(summary = "템플릿 구매 (무료 담기)", description = "무료 템플릿을 구매 내역에 추가합니다.")
+  public ResponseEntity<SuccessResponse<Void>> purchaseTemplate(
+      @PathVariable Long templateId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+    templatePurchaseService.purchaseFreeTemplate(userPrincipal.getUserProfile(), templateId);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(SuccessResponse.of("템플릿이 구매 내역에 담겼습니다.", null));
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
@@ -5,6 +5,7 @@ import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseServi
 import com.ll.readycode.global.common.auth.user.UserPrincipal;
 import com.ll.readycode.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,18 +13,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@RequiredArgsConstructor
+@Tag(name = "템플릿 구매 API", description = "템플릿 무료 구매 및 구매 내역 조회 관련 API")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/purchases")
 public class TemplatePurchaseController {
-
   private final TemplatePurchaseService templatePurchaseService;
 
   @PostMapping("/{templateId}")
   @Operation(summary = "템플릿 구매 (무료 담기)", description = "무료 템플릿을 구매 내역에 추가합니다.")
   public ResponseEntity<SuccessResponse<Void>> purchaseTemplate(
       @PathVariable Long templateId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
-
     templatePurchaseService.purchaseFreeTemplate(userPrincipal.getUserProfile(), templateId);
 
     return ResponseEntity.status(HttpStatus.CREATED)
@@ -34,7 +34,6 @@ public class TemplatePurchaseController {
   @Operation(summary = "마이페이지 구매 내역 조회", description = "사용자가 구매한 템플릿 목록을 조회합니다.")
   public ResponseEntity<SuccessResponse<List<PurchasedTemplateResponse>>> getMyPurchases(
       @AuthenticationPrincipal UserPrincipal userPrincipal) {
-
     List<PurchasedTemplateResponse> responses =
         templatePurchaseService.getPurchasedTemplates(userPrincipal.getUserProfile().getId());
 

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
@@ -1,17 +1,16 @@
 package com.ll.readycode.api.templates.controller;
 
+import com.ll.readycode.api.templates.dto.response.PurchasedTemplateResponse;
 import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
 import com.ll.readycode.global.common.auth.user.UserPrincipal;
 import com.ll.readycode.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -29,5 +28,16 @@ public class TemplatePurchaseController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.of("템플릿이 구매 내역에 담겼습니다.", null));
+  }
+
+  @GetMapping
+  @Operation(summary = "마이페이지 구매 내역 조회", description = "사용자가 구매한 템플릿 목록을 조회합니다.")
+  public ResponseEntity<SuccessResponse<List<PurchasedTemplateResponse>>> getMyPurchases(
+      @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+    List<PurchasedTemplateResponse> responses =
+        templatePurchaseService.getPurchasedTemplates(userPrincipal.getUserProfile().getId());
+
+    return ResponseEntity.ok(SuccessResponse.of("구매 내역 목록을 성공적으로 조회했습니다.", responses));
   }
 }

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplatePurchaseController.java
@@ -1,0 +1,14 @@
+package com.ll.readycode.api.templates.controller;
+
+import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/purchases")
+public class TemplatePurchaseController {
+
+  private final TemplatePurchaseService templatePurchaseService;
+}

--- a/backend/src/main/java/com/ll/readycode/api/templates/dto/response/PurchasedTemplateResponse.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/dto/response/PurchasedTemplateResponse.java
@@ -1,15 +1,17 @@
 package com.ll.readycode.api.templates.dto.response;
 
 import com.ll.readycode.domain.templates.templates.entity.Template;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "구매한 템플릿 응답 DTO")
 public record PurchasedTemplateResponse(
-    Long id,
-    String title,
-    String description,
-    int price,
-    String category,
-    LocalDateTime createdAt) {
+    @Schema(description = "템플릿 ID", example = "1") Long id,
+    @Schema(description = "템플릿 제목", example = "JWT 로그인 템플릿") String title,
+    @Schema(description = "템플릿 설명", example = "JWT를 이용한 로그인 기능 템플릿입니다.") String description,
+    @Schema(description = "템플릿 가격", example = "100") int price,
+    @Schema(description = "카테고리 이름", example = "백엔드") String category,
+    @Schema(description = "템플릿 생성일시", example = "2025-08-03T13:44:00") LocalDateTime createdAt) {
   public static PurchasedTemplateResponse of(Template template) {
     return new PurchasedTemplateResponse(
         template.getId(),

--- a/backend/src/main/java/com/ll/readycode/api/templates/dto/response/PurchasedTemplateResponse.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/dto/response/PurchasedTemplateResponse.java
@@ -1,0 +1,22 @@
+package com.ll.readycode.api.templates.dto.response;
+
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import java.time.LocalDateTime;
+
+public record PurchasedTemplateResponse(
+    Long id,
+    String title,
+    String description,
+    int price,
+    String category,
+    LocalDateTime createdAt) {
+  public static PurchasedTemplateResponse of(Template template) {
+    return new PurchasedTemplateResponse(
+        template.getId(),
+        template.getTitle(),
+        template.getDescription(),
+        template.getPrice(),
+        template.getCategory().getName(),
+        template.getCreatedAt());
+  }
+}

--- a/backend/src/main/java/com/ll/readycode/api/templates/dto/response/TemplateDetailResponse.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/dto/response/TemplateDetailResponse.java
@@ -15,8 +15,9 @@ public record TemplateDetailResponse(
     @Schema(description = "가격 (포인트)", example = "300") int price,
     @Schema(description = "카테고리 이름", example = "백엔드") String category,
     @Schema(description = "생성일시", example = "2024-12-10T12:00:00") LocalDateTime createdAt,
-    @Schema(description = "수정일시", example = "2024-12-11T13:00:00") LocalDateTime updatedAt) {
-  public static TemplateDetailResponse of(Template template) {
+    @Schema(description = "수정일시", example = "2024-12-11T13:00:00") LocalDateTime updatedAt,
+    @Schema(description = "사용자 구매 여부", example = "true") boolean purchased) {
+  public static TemplateDetailResponse of(Template template, boolean purchased) {
     return TemplateDetailResponse.builder()
         .templateId(template.getId())
         .title(template.getTitle())
@@ -26,6 +27,7 @@ public record TemplateDetailResponse(
         .category(template.getCategory().getName())
         .createdAt(template.getCreatedAt())
         .updatedAt(template.getUpdatedAt())
+        .purchased(purchased)
         .build();
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/fileupload/entity/FileUpload.java
+++ b/backend/src/main/java/com/ll/readycode/domain/fileupload/entity/FileUpload.java
@@ -1,4 +1,0 @@
-package com.ll.readycode.domain.fileupload.entity;
-
-public class FileUpload {
-}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/downloads/entity/TemplateDownload.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/downloads/entity/TemplateDownload.java
@@ -1,0 +1,33 @@
+package com.ll.readycode.domain.templates.downloads.entity;
+
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.common.entity.BaseCreatedOnlyEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+public class TemplateDownload extends BaseCreatedOnlyEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private UserProfile user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_id", nullable = false)
+  private Template template;
+
+  @Column(nullable = false)
+  private String ipAddress;
+
+  @Column(nullable = true)
+  private String device;
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/downloads/repository/TemplateDownloadRepository.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/downloads/repository/TemplateDownloadRepository.java
@@ -1,0 +1,10 @@
+package com.ll.readycode.domain.templates.downloads.repository;
+
+import com.ll.readycode.domain.templates.downloads.entity.TemplateDownload;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateDownloadRepository extends JpaRepository<TemplateDownload, Long> {
+  List<TemplateDownload> findByUser(UserProfile user);
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/downloads/service/TemplateDownloadService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/downloads/service/TemplateDownloadService.java
@@ -1,0 +1,12 @@
+package com.ll.readycode.domain.templates.downloads.service;
+
+import com.ll.readycode.domain.templates.downloads.repository.TemplateDownloadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TemplateDownloadService {
+
+  private final TemplateDownloadRepository templateDownloadRepository;
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/entity/TemplateFile.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/entity/TemplateFile.java
@@ -1,0 +1,31 @@
+package com.ll.readycode.domain.templates.files.entity;
+
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.global.common.entity.BaseCreatedOnlyEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@Entity
+public class TemplateFile extends BaseCreatedOnlyEntity {
+  @Column(nullable = false)
+  private String originalName;
+
+  @Column(nullable = false, length = 512)
+  private String url;
+
+  @Column(nullable = false, length = 50)
+  private String extension;
+
+  @Column(nullable = false)
+  private Long fileSize;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_id", nullable = false)
+  private Template template;
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/repository/TemplateFileRepository.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/repository/TemplateFileRepository.java
@@ -1,0 +1,8 @@
+package com.ll.readycode.domain.templates.files.repository;
+
+import com.ll.readycode.domain.templates.files.entity.TemplateFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TemplateFileRepository extends JpaRepository<TemplateFile, Long> {}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
@@ -1,0 +1,15 @@
+package com.ll.readycode.domain.templates.files.service;
+
+import com.ll.readycode.domain.templates.files.repository.TemplateFileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TemplateFileService {
+
+  private final TemplateFileRepository templateFileRepository;
+
+  private static final String BASE_DIR = "uploads/templates/";
+  private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/entity/TemplatePurchase.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/entity/TemplatePurchase.java
@@ -1,0 +1,30 @@
+package com.ll.readycode.domain.templates.purchases.entity;
+
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.common.entity.BaseCreatedOnlyEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+public class TemplatePurchase extends BaseCreatedOnlyEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "buyer_id", nullable = false)
+  private UserProfile buyer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_id", nullable = false)
+  private Template template;
+
+  @Column(nullable = false)
+  private int price;
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/entity/TemplatePurchase.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/entity/TemplatePurchase.java
@@ -15,6 +15,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @Entity
+@Table(
+    name = "template_purchases",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"buyer_id", "template_id"})})
 public class TemplatePurchase extends BaseCreatedOnlyEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/repository/TemplatePurchaseRepository.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/repository/TemplatePurchaseRepository.java
@@ -1,0 +1,12 @@
+package com.ll.readycode.domain.templates.purchases.repository;
+
+import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplatePurchaseRepository extends JpaRepository<TemplatePurchase, Long> {
+
+  boolean existsByBuyerIdAndTemplateId(Long buyerId, Long templateId);
+
+  List<TemplatePurchase> findByBuyerId(Long buyerId);
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/repository/TemplatePurchaseRepository.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/repository/TemplatePurchaseRepository.java
@@ -3,10 +3,19 @@ package com.ll.readycode.domain.templates.purchases.repository;
 import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TemplatePurchaseRepository extends JpaRepository<TemplatePurchase, Long> {
 
   boolean existsByBuyerIdAndTemplateId(Long buyerId, Long templateId);
 
-  List<TemplatePurchase> findByBuyerId(Long buyerId);
+  @Query(
+"""
+    SELECT tp FROM TemplatePurchase tp
+    JOIN FETCH tp.template
+    WHERE tp.buyer.id = :buyerId
+    ORDER BY tp.createdAt DESC
+""")
+  List<TemplatePurchase> findByBuyerIdWithTemplate(@Param("buyerId") Long buyerId);
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -58,4 +58,9 @@ public class TemplatePurchaseService {
         .map(purchase -> PurchasedTemplateResponse.of(purchase.getTemplate()))
         .toList();
   }
+
+  @Transactional(readOnly = true)
+  public boolean existsByBuyerIdAndTemplateId(Long buyerId, Long templateId) {
+    return templatePurchaseRepository.existsByBuyerIdAndTemplateId(buyerId, templateId);
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -1,5 +1,6 @@
 package com.ll.readycode.domain.templates.purchases.service;
 
+import com.ll.readycode.api.templates.dto.response.PurchasedTemplateResponse;
 import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
 import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
 import com.ll.readycode.domain.templates.templates.entity.Template;
@@ -7,6 +8,7 @@ import com.ll.readycode.domain.templates.templates.service.TemplateService;
 import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -45,5 +47,15 @@ public class TemplatePurchaseService {
     } catch (DataIntegrityViolationException e) {
       throw new CustomException(ErrorCode.ALREADY_PURCHASED);
     }
+  }
+
+  @Transactional(readOnly = true)
+  public List<PurchasedTemplateResponse> getPurchasedTemplates(Long userId) {
+    List<TemplatePurchase> purchases = templatePurchaseRepository.findByBuyerIdWithTemplate(userId);
+
+    return purchases.stream()
+        .sorted((p1, p2) -> p2.getCreatedAt().compareTo(p1.getCreatedAt()))
+        .map(purchase -> PurchasedTemplateResponse.of(purchase.getTemplate()))
+        .toList();
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -1,0 +1,12 @@
+package com.ll.readycode.domain.templates.purchases.service;
+
+import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TemplatePurchaseService {
+
+  private final TemplatePurchaseRepository templatePurchaseRepository;
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -1,12 +1,49 @@
 package com.ll.readycode.domain.templates.purchases.service;
 
+import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
 import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.domain.templates.templates.service.TemplateService;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.exception.CustomException;
+import com.ll.readycode.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class TemplatePurchaseService {
 
   private final TemplatePurchaseRepository templatePurchaseRepository;
+  private final TemplateService templateService;
+
+  @Transactional
+  public void purchaseFreeTemplate(UserProfile userProfile, Long templateId) {
+    boolean alreadyPurchased =
+        templatePurchaseRepository.existsByBuyerIdAndTemplateId(userProfile.getId(), templateId);
+    if (alreadyPurchased) {
+      throw new CustomException(ErrorCode.ALREADY_PURCHASED);
+    }
+
+    Template template = templateService.findTemplateById(templateId);
+
+    if (template.getPrice() > 0) {
+      throw new CustomException(ErrorCode.NOT_FREE_TEMPLATE);
+    }
+
+    TemplatePurchase templatePurchase =
+        TemplatePurchase.builder()
+            .buyer(userProfile)
+            .template(template)
+            .price(template.getPrice())
+            .build();
+
+    try {
+      templatePurchaseRepository.save(templatePurchase);
+    } catch (DataIntegrityViolationException e) {
+      throw new CustomException(ErrorCode.ALREADY_PURCHASED);
+    }
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -50,10 +50,12 @@ public class TemplatePurchaseService {
   }
 
   @Transactional(readOnly = true)
+  // TODO: 삭제된 템플릿에 대한 정책 정의 필요 (구매 내역에 표시 vs 숨김)
   public List<PurchasedTemplateResponse> getPurchasedTemplates(Long userId) {
     List<TemplatePurchase> purchases = templatePurchaseRepository.findByBuyerIdWithTemplate(userId);
 
     return purchases.stream()
+        .filter(purchase -> purchase.getTemplate() != null)
         .sorted((p1, p2) -> p2.getCreatedAt().compareTo(p1.getCreatedAt()))
         .map(purchase -> PurchasedTemplateResponse.of(purchase.getTemplate()))
         .toList();

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templatedownloads/entity/TemplatedDownload.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templatedownloads/entity/TemplatedDownload.java
@@ -1,4 +1,0 @@
-package com.ll.readycode.domain.templates.templatedownloads.entity;
-
-public class TemplatedDownload {
-}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templatepurchases/entity/TemplatePurchase.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templatepurchases/entity/TemplatePurchase.java
@@ -1,4 +1,0 @@
-package com.ll.readycode.domain.templates.templatepurchases.entity;
-
-public class TemplatePurchase {
-}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/entity/Template.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/entity/Template.java
@@ -1,6 +1,7 @@
 package com.ll.readycode.domain.templates.templates.entity;
 
 import com.ll.readycode.domain.categories.entity.Category;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
 import com.ll.readycode.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -30,9 +31,9 @@ public class Template extends BaseEntity {
   @JoinColumn(name = "category_id", nullable = false)
   private Category category;
 
-  //  @ManyToOne(fetch = FetchType.LAZY)
-  //  @JoinColumn(name = "seller_id", nullable = false)
-  //  private UserProfile seller;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "seller_id", nullable = false)
+  private UserProfile seller;
 
   public void update(String title, String description, int price, String image, Category category) {
     this.title = title;

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
@@ -8,6 +8,7 @@ import com.ll.readycode.domain.categories.entity.Category;
 import com.ll.readycode.domain.categories.service.CategoryService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.repository.TemplateRepository;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
 import jakarta.validation.Valid;
@@ -24,7 +25,7 @@ public class TemplateService {
   private final CategoryService categoryService;
 
   @Transactional
-  public Template create(TemplateCreateRequest request) {
+  public Template create(TemplateCreateRequest request, UserProfile userProfile) {
     Category category = categoryService.findCategoryById(request.categoryId());
     // TODO: 추후 인증 구현 후 SecurityContext에서 seller(UserProfile) 가져오기
 
@@ -35,6 +36,7 @@ public class TemplateService {
             .image(request.image())
             .price(request.price())
             .category(category)
+            .seller(userProfile)
             .build();
 
     templateRepository.save(template);

--- a/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
   ALREADY_PURCHASED(HttpStatus.CONFLICT, "TP001", "이미 구매한 템플릿입니다."),
   PURCHASE_NOT_FOUND(HttpStatus.NOT_FOUND, "TP002", "구매 내역을 찾을 수 없습니다."),
   INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "TP003", "포인트가 부족합니다."),
+  NOT_FREE_TEMPLATE(HttpStatus.BAD_REQUEST, "TP004", "유료 템플릿은 해당 API로 구매할 수 없습니다."),
 
   // 템플릿 다운로드 (TemplateDownload)
   DOWNLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TD001", "다운로드 횟수를 초과했습니다."),

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplatePurchaseServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplatePurchaseServiceTest.java
@@ -1,0 +1,135 @@
+package com.ll.readycode.domain.templates;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
+import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
+import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.domain.templates.templates.service.TemplateService;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.domain.users.userprofiles.entity.UserPurpose;
+import com.ll.readycode.domain.users.userprofiles.entity.UserRole;
+import com.ll.readycode.global.exception.CustomException;
+import com.ll.readycode.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class TemplatePurchaseServiceTest {
+
+  @InjectMocks private TemplatePurchaseService templatePurchaseService;
+
+  @Mock private TemplatePurchaseRepository templatePurchaseRepository;
+  @Mock private TemplateService templateService;
+
+  private final Long userId = 1L;
+  private final Long templateId = 10L;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  private UserProfile mockUser() {
+    return UserProfile.builder()
+        .nickname("abc")
+        .phoneNumber("010")
+        .role(UserRole.USER)
+        .purpose(UserPurpose.LEARNING)
+        .build();
+  }
+
+  private Template mockTemplate(int price) {
+    return Template.builder().id(templateId).price(price).build();
+  }
+
+  private TemplatePurchase mockPurchase(Template template) {
+    return TemplatePurchase.builder()
+        .buyer(mockUser())
+        .template(template)
+        .price(template != null ? template.getPrice() : 0)
+        .build();
+  }
+
+  @Test
+  @DisplayName("무료 템플릿 구매 성공")
+  void purchaseFreeTemplate_success() {
+    // given
+    UserProfile user = mockUser();
+    Template template = mockTemplate(0);
+
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
+        .willReturn(false);
+    given(templateService.findTemplateById(templateId)).willReturn(template);
+    given(templatePurchaseRepository.save(any())).willReturn(null);
+
+    // when & then
+    assertThatCode(() -> templatePurchaseService.purchaseFreeTemplate(user, templateId))
+        .doesNotThrowAnyException();
+  }
+
+  // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
+  /*  @Test
+  @DisplayName("이미 구매한 템플릿 예외처리")
+  void purchaseFreeTemplate_fails_whenAlreadyPurchased() {
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
+        .willReturn(true);
+
+    CustomException ex =
+        assertThrows(
+            CustomException.class,
+            () -> templatePurchaseService.purchaseFreeTemplate(mockUser(), templateId));
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PURCHASED);
+  }*/
+
+  @Test
+  @DisplayName("유료 템플릿을 무료 구매 API 구매시 예외처리")
+  void purchaseFreeTemplate_fails_whenTemplateIsNotFree() {
+    Template template = mockTemplate(100);
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
+        .willReturn(false);
+    given(templateService.findTemplateById(templateId)).willReturn(template);
+
+    CustomException ex =
+        assertThrows(
+            CustomException.class,
+            () -> templatePurchaseService.purchaseFreeTemplate(mockUser(), templateId));
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FREE_TEMPLATE);
+  }
+
+  // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
+  /*  @Test
+  @DisplayName("구매한 템플릿 중 삭제된 템플릿 응답에서 제외")
+  void getPurchasedTemplates_filtersOutNullTemplates() {
+    Template validTemplate = mockTemplate(0);
+    TemplatePurchase validPurchase = mockPurchase(validTemplate);
+    TemplatePurchase nullTemplatePurchase = mockPurchase(null);
+
+    given(templatePurchaseRepository.findByBuyerIdWithTemplate(userId))
+        .willReturn(List.of(validPurchase, nullTemplatePurchase));
+
+    List<PurchasedTemplateResponse> result = templatePurchaseService.getPurchasedTemplates(userId);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).id()).isEqualTo(validTemplate.getId());
+  }*/
+
+  @Test
+  @DisplayName("특정 템플릿의 구매 여부 확인")
+  void existsByBuyerIdAndTemplateId_returnsTrue_whenPurchased() {
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
+        .willReturn(true);
+
+    boolean result = templatePurchaseService.existsByBuyerIdAndTemplateId(userId, templateId);
+
+    assertThat(result).isTrue();
+  }
+}

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplatePurchaseServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplatePurchaseServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
 import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
 import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
@@ -16,55 +15,38 @@ import com.ll.readycode.domain.users.userprofiles.entity.UserPurpose;
 import com.ll.readycode.domain.users.userprofiles.entity.UserRole;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TemplatePurchaseServiceTest {
 
   @InjectMocks private TemplatePurchaseService templatePurchaseService;
 
   @Mock private TemplatePurchaseRepository templatePurchaseRepository;
+
   @Mock private TemplateService templateService;
 
   private final Long userId = 1L;
   private final Long templateId = 10L;
 
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
-  }
-
-  private UserProfile mockUser() {
-    return UserProfile.builder()
-        .nickname("abc")
-        .phoneNumber("010")
-        .role(UserRole.USER)
-        .purpose(UserPurpose.LEARNING)
-        .build();
-  }
-
-  private Template mockTemplate(int price) {
-    return Template.builder().id(templateId).price(price).build();
-  }
-
-  private TemplatePurchase mockPurchase(Template template) {
-    return TemplatePurchase.builder()
-        .buyer(mockUser())
-        .template(template)
-        .price(template != null ? template.getPrice() : 0)
-        .build();
-  }
+  UserProfile user =
+      UserProfile.builder()
+          .nickname("abc")
+          .phoneNumber("010")
+          .role(UserRole.USER)
+          .purpose(UserPurpose.LEARNING)
+          .build();
 
   @Test
   @DisplayName("무료 템플릿 구매 성공")
   void purchaseFreeTemplate_success() {
     // given
-    UserProfile user = mockUser();
-    Template template = mockTemplate(0);
+    Template template = Template.builder().id(templateId).price(0).build();
 
     given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
         .willReturn(false);
@@ -77,50 +59,38 @@ class TemplatePurchaseServiceTest {
   }
 
   // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
-  /*  @Test
+  /*
+  @Test
   @DisplayName("이미 구매한 템플릿 예외처리")
   void purchaseFreeTemplate_fails_whenAlreadyPurchased() {
-    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
-        .willReturn(true);
+      given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
+              .willReturn(true);
 
-    CustomException ex =
-        assertThrows(
-            CustomException.class,
-            () -> templatePurchaseService.purchaseFreeTemplate(mockUser(), templateId));
-    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PURCHASED);
-  }*/
+      CustomException ex = assertThrows(CustomException.class,
+              () -> templatePurchaseService.purchaseFreeTemplate(user, templateId));
+
+      assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PURCHASED);
+  }
+  */
 
   @Test
   @DisplayName("유료 템플릿을 무료 구매 API 구매시 예외처리")
   void purchaseFreeTemplate_fails_whenTemplateIsNotFree() {
-    Template template = mockTemplate(100);
+    // given
+    Template paidTemplate = Template.builder().id(templateId).price(100).build();
+
     given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
         .willReturn(false);
-    given(templateService.findTemplateById(templateId)).willReturn(template);
+    given(templateService.findTemplateById(templateId)).willReturn(paidTemplate);
 
+    // when & then
     CustomException ex =
         assertThrows(
             CustomException.class,
-            () -> templatePurchaseService.purchaseFreeTemplate(mockUser(), templateId));
+            () -> templatePurchaseService.purchaseFreeTemplate(user, templateId));
+
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FREE_TEMPLATE);
   }
-
-  // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
-  /*  @Test
-  @DisplayName("구매한 템플릿 중 삭제된 템플릿 응답에서 제외")
-  void getPurchasedTemplates_filtersOutNullTemplates() {
-    Template validTemplate = mockTemplate(0);
-    TemplatePurchase validPurchase = mockPurchase(validTemplate);
-    TemplatePurchase nullTemplatePurchase = mockPurchase(null);
-
-    given(templatePurchaseRepository.findByBuyerIdWithTemplate(userId))
-        .willReturn(List.of(validPurchase, nullTemplatePurchase));
-
-    List<PurchasedTemplateResponse> result = templatePurchaseService.getPurchasedTemplates(userId);
-
-    assertThat(result).hasSize(1);
-    assertThat(result.get(0).id()).isEqualTo(validTemplate.getId());
-  }*/
 
   @Test
   @DisplayName("특정 템플릿의 구매 여부 확인")
@@ -132,4 +102,36 @@ class TemplatePurchaseServiceTest {
 
     assertThat(result).isTrue();
   }
+
+  // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
+  /*
+  @Test
+  @DisplayName("구매한 템플릿 중 삭제된 템플릿 응답에서 제외")
+  void getPurchasedTemplates_filtersOutNullTemplates() {
+      Template validTemplate = Template.builder()
+              .id(templateId)
+              .price(0)
+              .build();
+
+      TemplatePurchase validPurchase = TemplatePurchase.builder()
+              .buyer(user)
+              .template(validTemplate)
+              .price(0)
+              .build();
+
+      TemplatePurchase nullTemplatePurchase = TemplatePurchase.builder()
+              .buyer(user)
+              .template(null)
+              .price(0)
+              .build();
+
+      given(templatePurchaseRepository.findByBuyerIdWithTemplate(userId))
+              .willReturn(List.of(validPurchase, nullTemplatePurchase));
+
+      List<PurchasedTemplateResponse> result = templatePurchaseService.getPurchasedTemplates(userId);
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).id()).isEqualTo(validTemplate.getId());
+  }
+  */
 }

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplateServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplateServiceTest.java
@@ -12,6 +12,9 @@ import com.ll.readycode.domain.categories.service.CategoryService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.repository.TemplateRepository;
 import com.ll.readycode.domain.templates.templates.service.TemplateService;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.domain.users.userprofiles.entity.UserPurpose;
+import com.ll.readycode.domain.users.userprofiles.entity.UserRole;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -34,6 +37,14 @@ class TemplateServiceTest {
 
   Category category1 = Category.builder().id(1L).name("백엔드").build();
   Category category2 = Category.builder().id(2L).name("프론트").build();
+
+  UserProfile userProfile =
+      UserProfile.builder()
+          .nickname("abc")
+          .phoneNumber("010")
+          .role(UserRole.USER)
+          .purpose(UserPurpose.LEARNING)
+          .build();
 
   private Template createTemplate(
       Long id, String title, Category category, LocalDateTime localDateTime) {
@@ -58,7 +69,7 @@ class TemplateServiceTest {
     given(templateRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
     // when
-    Template result = templateService.create(request);
+    Template result = templateService.create(request, userProfile);
 
     // then
     assertThat(result.getTitle()).isEqualTo("로그인 템플릿");


### PR DESCRIPTION
## 🛰 Issue Number
 #28 

## 🪐 작업 내용
- 엔티티 및 리포, 서비스, 컨트롤러 도메인 설계
- 구매내역에 담기 로직 구현
- 템플릿 상세 조회 api에 구매 여부 로직 추가
- 현재 사용자가 구매한 템플릿 목록 조회
- 템플릿 목록 조회 시 삭제된 템플릿일때 예외 처리
- 단위 테스트 작성

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?