### PR TITLE
Be/feat/template-download

### DIFF
--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -5,6 +5,7 @@ import com.ll.readycode.api.templates.dto.request.TemplateUpdateRequest;
 import com.ll.readycode.api.templates.dto.response.TemplateDetailResponse;
 import com.ll.readycode.api.templates.dto.response.TemplateResponse;
 import com.ll.readycode.api.templates.dto.response.TemplateScrollResponse;
+import com.ll.readycode.domain.templates.downloads.service.TemplateDownloadService;
 import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.service.TemplateService;
@@ -12,9 +13,11 @@ import com.ll.readycode.global.common.auth.user.UserPrincipal;
 import com.ll.readycode.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class TemplateController {
   private final TemplateService templateService;
   private final TemplatePurchaseService templatePurchaseService;
+  private final TemplateDownloadService templateDownloadService;
 
   @Operation(summary = "템플릿 목록 조회", description = "템플릿을 최신순 기준으로 커서 기반 페이징 방식으로 조회합니다.")
   @GetMapping
@@ -83,5 +87,18 @@ public class TemplateController {
   public ResponseEntity<SuccessResponse> deleteTemplate(@PathVariable Long templatesId) {
     templateService.delete(templatesId);
     return ResponseEntity.ok(SuccessResponse.of("게시물이 성공적으로 삭제되었습니다.", null));
+  }
+
+  @GetMapping("/{templateId}/download")
+  public ResponseEntity<Resource> downloadTemplate(
+      @PathVariable Long templateId,
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      HttpServletRequest request) {
+
+    String ip = request.getRemoteAddr();
+    String userAgent = request.getHeader("User-Agent");
+
+    return templateDownloadService.downloadTemplate(
+        templateId, userPrincipal.getUserProfile(), ip, userAgent);
   }
 }

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "템플릿 API", description = "템플릿 조회, 생성, 수정, 삭제 등의 기능을 제공합니다.")
 @RequestMapping("/api/templates")
@@ -60,9 +61,10 @@ public class TemplateController {
   @Operation(summary = "템플릿 생성", description = "템플릿을 생성합니다.")
   @PostMapping
   public ResponseEntity<SuccessResponse<TemplateResponse>> createTemplate(
-      @Valid @RequestBody TemplateCreateRequest request,
+      @RequestPart("template") @Valid TemplateCreateRequest request,
+      @RequestPart("file") MultipartFile file,
       @AuthenticationPrincipal UserPrincipal userPrincipal) {
-    Template template = templateService.create(request, userPrincipal.getUserProfile());
+    Template template = templateService.create(request, file, userPrincipal.getUserProfile());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.of("게시물이 성공적으로 생성되었습니다.", TemplateResponse.of(template)));
   }

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -63,7 +64,7 @@ public class TemplateController {
   }
 
   @Operation(summary = "템플릿 생성", description = "템플릿을 생성합니다.")
-  @PostMapping
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<SuccessResponse<TemplateResponse>> createTemplate(
       @RequestPart("template") @Valid TemplateCreateRequest request,
       @RequestPart("file") MultipartFile file,
@@ -74,18 +75,23 @@ public class TemplateController {
   }
 
   @Operation(summary = "템플릿 수정", description = "템플릿 ID를 기준으로 수정합니다.")
-  @PatchMapping("/{templatesId}")
+  @PatchMapping(value = "/{templateId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<SuccessResponse<TemplateResponse>> modifyTemplate(
-      @Valid @RequestBody TemplateUpdateRequest request, @PathVariable Long templatesId) {
-    Template template = templateService.update(templatesId, request);
+      @RequestPart("request") @Valid TemplateUpdateRequest request,
+      @RequestPart(value = "file", required = false) MultipartFile file,
+      @PathVariable Long templateId,
+      @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    Template template =
+        templateService.update(templateId, request, userPrincipal.getUserProfile(), file);
     return ResponseEntity.ok(
         SuccessResponse.of("게시물이 성공적으로 수정되었습니다.", TemplateResponse.of(template)));
   }
 
   @Operation(summary = "템플릿 삭제", description = "템플릿 ID를 기준으로 삭제합니다.")
   @DeleteMapping("/{templatesId}")
-  public ResponseEntity<SuccessResponse> deleteTemplate(@PathVariable Long templatesId) {
-    templateService.delete(templatesId);
+  public ResponseEntity<SuccessResponse> deleteTemplate(
+      @PathVariable Long templatesId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    templateService.delete(templatesId, userPrincipal.getUserProfile());
     return ResponseEntity.ok(SuccessResponse.of("게시물이 성공적으로 삭제되었습니다.", null));
   }
 

--- a/backend/src/main/java/com/ll/readycode/domain/templates/downloads/service/TemplateDownloadService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/downloads/service/TemplateDownloadService.java
@@ -1,12 +1,152 @@
 package com.ll.readycode.domain.templates.downloads.service;
 
+import com.ll.readycode.domain.templates.downloads.entity.TemplateDownload;
 import com.ll.readycode.domain.templates.downloads.repository.TemplateDownloadRepository;
+import com.ll.readycode.domain.templates.files.entity.TemplateFile;
+import com.ll.readycode.domain.templates.files.service.TemplateFileService;
+import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.domain.templates.templates.service.TemplateService;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.common.auth.oauth.properties.TemplateFileProperties;
+import com.ll.readycode.global.exception.CustomException;
+import com.ll.readycode.global.exception.ErrorCode;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriUtils;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class TemplateDownloadService {
 
+  private final TemplatePurchaseService templatePurchaseService;
+  private final TemplateFileService templateFileService;
   private final TemplateDownloadRepository templateDownloadRepository;
+  private final TemplateService templateService;
+  private final TemplateFileProperties properties;
+
+  public ResponseEntity<Resource> downloadTemplate(
+      Long templateId, UserProfile userProfile, String ipAddress, String deviceInfo) {
+
+    try {
+      // 구매 여부 확인
+      templatePurchaseService.throwIfNotPurchased(userProfile.getId(), templateId);
+
+      // 템플릿 파일 정보 조회
+      TemplateFile templateFile = templateFileService.findByTemplateId(templateId);
+
+      // 파일 경로 보안 검증
+      Path filePath = validateAndResolvePath(templateFile.getUrl());
+      File file = filePath.toFile();
+
+      // 파일 존재 및 접근 가능성 확인
+      if (!file.exists()) {
+        throw new CustomException(ErrorCode.DOWNLOAD_NOT_FOUND);
+      }
+
+      if (!file.canRead()) {
+        throw new CustomException(ErrorCode.FILE_READ_ERROR);
+      }
+
+      // 파일 크기 제한 확인
+      if (file.length() > properties.getMaxSize().toBytes()) {
+        throw new CustomException(ErrorCode.FILE_TOO_LARGE);
+      }
+
+      // 템플릿 정보 조회
+      Template template = templateService.findTemplateById(templateId);
+
+      // 다운로드 로그 기록 (별도 트랜잭션으로 처리)
+      logTemplateDownload(userProfile, template, ipAddress, deviceInfo);
+
+      // 리소스 생성 및 응답
+      Resource resource = new FileSystemResource(file);
+      String encodedFilename =
+          UriUtils.encode(templateFile.getOriginalFilename(), StandardCharsets.UTF_8);
+
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_OCTET_STREAM)
+          .contentLength(file.length())
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + encodedFilename + "\"")
+          .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+          .body(resource);
+
+    } catch (IOException e) {
+      throw new CustomException(ErrorCode.FILE_READ_ERROR);
+    } catch (Exception e) {
+      throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /** 파일 경로의 보안성을 검증하고 안전한 Path 를 반환 */
+  private Path validateAndResolvePath(String fileUrl) throws IOException {
+    try {
+      // 설정에서 가져오거나 환경변수로 관리하는 것이 좋음
+      Path basePath = Paths.get(properties.getBaseDir()).normalize();
+      Path requestedPath = Paths.get(fileUrl).normalize();
+
+      // 절대 경로로 변환
+      Path resolvedPath = basePath.resolve(requestedPath).normalize();
+
+      // 기본 디렉토리를 벗어나는지 확인 (Directory Traversal 공격 방지)
+      if (!resolvedPath.startsWith(basePath)) {
+        log.warn("Directory traversal attempt detected. Requested path: {}", fileUrl);
+        throw new CustomException(ErrorCode.INVALID_FILE_PATH);
+      }
+
+      return resolvedPath;
+
+    } catch (InvalidPathException e) {
+      log.warn("Invalid file path requested: {}", fileUrl);
+      throw new CustomException(ErrorCode.INVALID_FILE_PATH);
+    }
+  }
+
+  /** 다운로드 로그를 별도 트랜잭션으로 기록 */
+  @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  private void logTemplateDownload(
+      UserProfile userProfile, Template template, String ipAddress, String deviceInfo) {
+    try {
+      TemplateDownload downloadLog =
+          TemplateDownload.builder()
+              .user(userProfile)
+              .template(template)
+              .ipAddress(ipAddress)
+              .device(deviceInfo)
+              .build();
+
+      templateDownloadRepository.save(downloadLog);
+      log.info(
+          "Template download started. TemplateId: {}, UserId: {}",
+          template.getId(),
+          userProfile.getId());
+      logTemplateDownload(userProfile, template, ipAddress, deviceInfo);
+
+    } catch (Exception e) {
+      // 로그 저장 실패가 다운로드 자체를 방해하지 않도록 함
+      log.error(
+          "Failed to log template download. TemplateId: {}, UserId: {}",
+          template.getId(),
+          userProfile.getId(),
+          e);
+    }
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/downloads/service/TemplateDownloadService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/downloads/service/TemplateDownloadService.java
@@ -91,6 +91,7 @@ public class TemplateDownloadService {
     } catch (IOException e) {
       throw new CustomException(ErrorCode.FILE_READ_ERROR);
     } catch (Exception e) {
+      log.error("downloadTemplate 실패", e);
       throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
     }
   }
@@ -138,7 +139,6 @@ public class TemplateDownloadService {
           "Template download started. TemplateId: {}, UserId: {}",
           template.getId(),
           userProfile.getId());
-      logTemplateDownload(userProfile, template, ipAddress, deviceInfo);
 
     } catch (Exception e) {
       // 로그 저장 실패가 다운로드 자체를 방해하지 않도록 함

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/entity/TemplateFile.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/entity/TemplateFile.java
@@ -14,7 +14,7 @@ import lombok.experimental.SuperBuilder;
 @Entity
 public class TemplateFile extends BaseCreatedOnlyEntity {
   @Column(nullable = false)
-  private String originalName;
+  private String originalFilename;
 
   @Column(nullable = false, length = 512)
   private String url;

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/entity/TemplateFile.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/entity/TemplateFile.java
@@ -28,4 +28,8 @@ public class TemplateFile extends BaseCreatedOnlyEntity {
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "template_id", nullable = false)
   private Template template;
+
+  public void setTemplate(Template template) {
+    this.template = template;
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/repository/TemplateFileRepository.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/repository/TemplateFileRepository.java
@@ -1,8 +1,11 @@
 package com.ll.readycode.domain.templates.files.repository;
 
 import com.ll.readycode.domain.templates.files.entity.TemplateFile;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TemplateFileRepository extends JpaRepository<TemplateFile, Long> {}
+public interface TemplateFileRepository extends JpaRepository<TemplateFile, Long> {
+  Optional<TemplateFile> findByTemplateId(Long templateId);
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
@@ -1,8 +1,16 @@
 package com.ll.readycode.domain.templates.files.service;
 
+import com.ll.readycode.domain.templates.files.entity.TemplateFile;
 import com.ll.readycode.domain.templates.files.repository.TemplateFileRepository;
+import com.ll.readycode.global.exception.CustomException;
+import com.ll.readycode.global.exception.ErrorCode;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -12,4 +20,75 @@ public class TemplateFileService {
 
   private static final String BASE_DIR = "uploads/templates/";
   private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+  public TemplateFile create(MultipartFile file) {
+    validateFile(file);
+    String savedPath = saveFile(file);
+    return createTemplateFile(file, savedPath);
+  }
+
+  private void validateFile(MultipartFile file) {
+    if (file.isEmpty()) {
+      throw new CustomException(ErrorCode.EMPTY_FILE);
+    }
+
+    String originalFilename = file.getOriginalFilename();
+    if (originalFilename == null || !originalFilename.contains(".")) {
+      throw new CustomException(ErrorCode.INVALID_FILENAME);
+    }
+    String extension = getFileExtension(originalFilename);
+
+    if (!isAllowedExtension(extension)) {
+      throw new CustomException(ErrorCode.UNSUPPORTED_EXTENSION);
+    }
+
+    if (file.getSize() > MAX_FILE_SIZE) {
+      throw new CustomException(ErrorCode.FILE_TOO_LARGE);
+    }
+  }
+
+  private String saveFile(MultipartFile file) {
+    String extension = getFileExtension(file.getOriginalFilename());
+    String uuid = UUID.randomUUID().toString();
+    String savedFileName = uuid + "." + extension;
+    String fullPath = BASE_DIR + savedFileName;
+
+    File directory = new File(BASE_DIR);
+    if (!directory.exists()) {
+      directory.mkdirs();
+    }
+
+    try {
+      file.transferTo(new File(fullPath));
+    } catch (IOException | IllegalStateException e) {
+      throw new CustomException(ErrorCode.FILE_SAVE_ERROR);
+    }
+
+    return fullPath;
+  }
+
+  private TemplateFile createTemplateFile(MultipartFile file, String savedPath) {
+    String extension = getFileExtension(file.getOriginalFilename());
+
+    TemplateFile templateFile =
+        TemplateFile.builder()
+            .originalName(file.getOriginalFilename())
+            .extension(extension)
+            .fileSize(file.getSize())
+            .url(savedPath)
+            .build();
+
+    return templateFileRepository.save(templateFile);
+  }
+
+  private String getFileExtension(String filename) {
+    if (filename == null || !filename.contains(".")) {
+      throw new CustomException(ErrorCode.UNSUPPORTED_EXTENSION);
+    }
+    return filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+  }
+
+  private boolean isAllowedExtension(String extension) {
+    return List.of("zip", "rar", "txt", "java", "pdf").contains(extension);
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
@@ -98,6 +98,17 @@ public class TemplateFileService {
     return create(newFile);
   }
 
+  public void deleteFile(TemplateFile templateFile) {
+    File physicalFile = new File(templateFile.getUrl());
+
+    if (physicalFile.exists()) {
+      boolean deleted = physicalFile.delete();
+      if (!deleted) {
+        throw new CustomException(ErrorCode.FILE_DELETE_FAILED);
+      }
+    }
+  }
+
   public TemplateFile findByTemplateId(Long templateId) {
     return templateFileRepository
         .findByTemplateId(templateId)

--- a/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/files/service/TemplateFileService.java
@@ -67,17 +67,15 @@ public class TemplateFileService {
   }
 
   private TemplateFile createTemplateFile(MultipartFile file, String savedPath) {
-    String extension = getFileExtension(file.getOriginalFilename());
+    String originalFilename = file.getOriginalFilename();
+    String extension = getFileExtension(originalFilename);
 
-    TemplateFile templateFile =
-        TemplateFile.builder()
-            .originalFilename(file.getOriginalFilename())
-            .extension(extension)
-            .fileSize(file.getSize())
-            .url(savedPath)
-            .build();
-
-    return templateFileRepository.save(templateFile);
+    return TemplateFile.builder()
+        .originalFilename(originalFilename)
+        .extension(extension)
+        .fileSize(file.getSize())
+        .url(savedPath)
+        .build();
   }
 
   private String getFileExtension(String filename) {
@@ -89,6 +87,15 @@ public class TemplateFileService {
 
   private boolean isAllowedExtension(String extension) {
     return List.of("zip", "rar", "txt", "java", "pdf").contains(extension);
+  }
+
+  public TemplateFile updateFile(TemplateFile oldFile, MultipartFile newFile) {
+    File file = new File(oldFile.getUrl());
+    if (file.exists()) {
+      file.delete();
+    }
+
+    return create(newFile);
   }
 
   public TemplateFile findByTemplateId(Long templateId) {

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -63,4 +63,12 @@ public class TemplatePurchaseService {
   public boolean existsByBuyerIdAndTemplateId(Long buyerId, Long templateId) {
     return templatePurchaseRepository.existsByBuyerIdAndTemplateId(buyerId, templateId);
   }
+
+  @Transactional(readOnly = true)
+  public void throwIfNotPurchased(Long userId, Long templateId) {
+    boolean purchased = templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId);
+    if (!purchased) {
+      throw new CustomException(ErrorCode.FORBIDDEN);
+    }
+  }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/entity/Template.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/entity/Template.java
@@ -1,6 +1,7 @@
 package com.ll.readycode.domain.templates.templates.entity;
 
 import com.ll.readycode.domain.categories.entity.Category;
+import com.ll.readycode.domain.templates.files.entity.TemplateFile;
 import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
 import com.ll.readycode.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -35,11 +36,23 @@ public class Template extends BaseEntity {
   @JoinColumn(name = "seller_id", nullable = false)
   private UserProfile seller;
 
+  @OneToOne(
+      mappedBy = "template",
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY)
+  private TemplateFile templateFile;
+
   public void update(String title, String description, int price, String image, Category category) {
     this.title = title;
     this.description = description;
     this.price = price;
     this.image = image;
     this.category = category;
+  }
+
+  public void setTemplateFile(TemplateFile templateFile) {
+    this.templateFile = templateFile;
+    templateFile.setTemplate(this);
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
@@ -6,6 +6,7 @@ import com.ll.readycode.api.templates.dto.response.TemplateScrollResponse;
 import com.ll.readycode.api.templates.dto.response.TemplateSummary;
 import com.ll.readycode.domain.categories.entity.Category;
 import com.ll.readycode.domain.categories.service.CategoryService;
+import com.ll.readycode.domain.templates.files.service.TemplateFileService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.repository.TemplateRepository;
 import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
@@ -17,17 +18,20 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class TemplateService {
   private final TemplateRepository templateRepository;
+  private final TemplateFileService templateFileService;
   private final CategoryService categoryService;
 
   @Transactional
-  public Template create(TemplateCreateRequest request, UserProfile userProfile) {
+  public Template create(
+      TemplateCreateRequest request, MultipartFile file, UserProfile userProfile) {
     Category category = categoryService.findCategoryById(request.categoryId());
-    // TODO: 추후 인증 구현 후 SecurityContext에서 seller(UserProfile) 가져오기
+    templateFileService.create(file);
 
     Template template =
         Template.builder()

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
@@ -77,6 +77,7 @@ public class TemplateService {
     Template template = findTemplateById(templatesId);
 
     validateTemplateOwner(template, userProfile.getId());
+    templateFileService.deleteFile(template.getTemplateFile());
     templateRepository.delete(template);
   }
 

--- a/backend/src/main/java/com/ll/readycode/global/common/auth/oauth/properties/TemplateFileProperties.java
+++ b/backend/src/main/java/com/ll/readycode/global/common/auth/oauth/properties/TemplateFileProperties.java
@@ -1,0 +1,16 @@
+package com.ll.readycode.global.common.auth.oauth.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
+
+@Component
+@ConfigurationProperties(prefix = "custom.template.file")
+@Getter
+@Setter
+public class TemplateFileProperties {
+  private String baseDir;
+  private DataSize maxSize;
+}

--- a/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   DUPLICATE_TEMPLATE(HttpStatus.CONFLICT, "T002", "이미 동일한 템플릿이 존재합니다."),
   TEMPLATE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "T003", "템플릿 업로드에 실패했습니다."),
   INVALID_TEMPLATE_META(HttpStatus.BAD_REQUEST, "T004", "템플릿 메타 정보가 유효하지 않습니다."),
+  TEMPLATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "T005", "템플릿에 대한 수정 권한이 없습니다."),
 
   // 템플릿 구매 (TemplatePurchase)
   ALREADY_PURCHASED(HttpStatus.CONFLICT, "TP001", "이미 구매한 템플릿입니다."),
@@ -52,7 +53,6 @@ public enum ErrorCode {
   FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "F004", "파일 크기가 허용치를 초과했습니다."),
   INVALID_FILENAME(HttpStatus.BAD_REQUEST, "F005", "파일 이름을 확인할 수 없습니다."),
 
-  // 템플릿 다운로드 (TemplateDownload)
   // 템플릿 다운로드 (TemplateDownload)
   DOWNLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TD001", "다운로드 횟수를 초과했습니다."),
   DOWNLOAD_NOT_FOUND(HttpStatus.NOT_FOUND, "TD002", "다운로드 내역이 존재하지 않습니다."),

--- a/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
@@ -53,8 +53,11 @@ public enum ErrorCode {
   INVALID_FILENAME(HttpStatus.BAD_REQUEST, "F005", "파일 이름을 확인할 수 없습니다."),
 
   // 템플릿 다운로드 (TemplateDownload)
+  // 템플릿 다운로드 (TemplateDownload)
   DOWNLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TD001", "다운로드 횟수를 초과했습니다."),
   DOWNLOAD_NOT_FOUND(HttpStatus.NOT_FOUND, "TD002", "다운로드 내역이 존재하지 않습니다."),
+  FILE_READ_ERROR(HttpStatus.NOT_FOUND, "TD003", "해당 파일을 불러올 수 없습니다."),
+  INVALID_FILE_PATH(HttpStatus.BAD_REQUEST, "TD004", "잘못된 파일 경로입니다."),
 
   // 리뷰 (Review)
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
   FILE_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 저장 중 오류가 발생했습니다."),
   FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "F004", "파일 크기가 허용치를 초과했습니다."),
   INVALID_FILENAME(HttpStatus.BAD_REQUEST, "F005", "파일 이름을 확인할 수 없습니다."),
+  FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F006", "파일 삭제에 실패했습니다."),
 
   // 템플릿 다운로드 (TemplateDownload)
   DOWNLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TD001", "다운로드 횟수를 초과했습니다."),

--- a/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
@@ -45,6 +45,13 @@ public enum ErrorCode {
   INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "TP003", "포인트가 부족합니다."),
   NOT_FREE_TEMPLATE(HttpStatus.BAD_REQUEST, "TP004", "유료 템플릿은 해당 API로 구매할 수 없습니다."),
 
+  // 파일 업로드 (File)
+  EMPTY_FILE(HttpStatus.BAD_REQUEST, "F001", "업로드할 파일이 비어 있습니다."),
+  UNSUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, "F002", "지원하지 않는 파일 확장자입니다."),
+  FILE_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 저장 중 오류가 발생했습니다."),
+  FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "F004", "파일 크기가 허용치를 초과했습니다."),
+  INVALID_FILENAME(HttpStatus.BAD_REQUEST, "F005", "파일 이름을 확인할 수 없습니다."),
+
   // 템플릿 다운로드 (TemplateDownload)
   DOWNLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TD001", "다운로드 횟수를 초과했습니다."),
   DOWNLOAD_NOT_FOUND(HttpStatus.NOT_FOUND, "TD002", "다운로드 내역이 존재하지 않습니다."),

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplateDownloadServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplateDownloadServiceTest.java
@@ -1,0 +1,169 @@
+package com.ll.readycode.domain.templates;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.ll.readycode.domain.templates.downloads.repository.TemplateDownloadRepository;
+import com.ll.readycode.domain.templates.downloads.service.TemplateDownloadService;
+import com.ll.readycode.domain.templates.files.entity.TemplateFile;
+import com.ll.readycode.domain.templates.files.service.TemplateFileService;
+import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
+import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
+import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.domain.templates.templates.service.TemplateService;
+import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.common.auth.oauth.properties.TemplateFileProperties;
+import com.ll.readycode.global.exception.CustomException;
+import com.ll.readycode.global.exception.ErrorCode;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.unit.DataSize;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TemplateDownloadServiceTest {
+
+  @InjectMocks private TemplateDownloadService downloadService;
+
+  @Mock private TemplatePurchaseService purchaseService;
+  @Mock private TemplateFileService templateFileService;
+  @Mock private TemplatePurchaseRepository templatePurchaseRepository;
+  @Mock private TemplateDownloadRepository templateDownloadRepository;
+  @Mock private TemplateService templateService;
+  @Mock private TemplateFileProperties properties;
+
+  private final UserProfile user = UserProfile.builder().id(1L).build();
+  private final Template template = Template.builder().id(1L).build();
+  private final String ip = "127.0.0.1";
+  private final String device = "Chrome";
+
+  private Path tempFilePath;
+
+  private TemplateFile createTemplateFile() {
+    return TemplateFile.builder()
+        .originalFilename("example.zip")
+        .url(tempFilePath.getFileName().toString())
+        .build();
+  }
+
+  @BeforeEach
+  void setup() throws IOException {
+    tempFilePath = Files.createTempFile("test", ".zip");
+    Files.writeString(tempFilePath, "sample content");
+
+    given(properties.getBaseDir()).willReturn(tempFilePath.getParent().toString() + "/");
+    given(properties.getMaxSize()).willReturn(DataSize.ofMegabytes(10));
+  }
+
+  @AfterEach
+  void cleanUp() throws IOException {
+    Files.deleteIfExists(tempFilePath);
+  }
+
+  @Test
+  @DisplayName("정상 다운로드 요청 시 파일 응답 반환")
+  void downloadTemplate_whenValid_thenReturnResponse() {
+    // given
+    TemplateFile templateFile = createTemplateFile();
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(user.getId(), 1L))
+        .willReturn(true);
+    given(templateFileService.findByTemplateId(1L)).willReturn(templateFile);
+    given(templateService.findTemplateById(1L)).willReturn(template);
+
+    // when
+    ResponseEntity<Resource> response = downloadService.downloadTemplate(1L, user, ip, device);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getContentDisposition().getFilename())
+        .isEqualTo("example.zip");
+    assertThat(response.getBody()).isInstanceOf(Resource.class);
+  }
+
+  @Test
+  @DisplayName("구매하지 않은 사용자는 예외 발생")
+  void downloadTemplate_whenNotPurchased_thenThrowException() {
+    // given
+    willThrow(new CustomException(ErrorCode.PURCHASE_NOT_FOUND))
+        .given(purchaseService)
+        .throwIfNotPurchased(user.getId(), 1L);
+
+    // then
+    assertThrows(
+        CustomException.class, () -> downloadService.downloadTemplate(1L, user, ip, device));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 파일 요청 시 예외 발생")
+  void downloadTemplate_whenFileNotExists_thenThrowException() {
+    // given
+    TemplateFile nonExistFile =
+        TemplateFile.builder().originalFilename("nope.zip").url("nonexistent.zip").build();
+
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(user.getId(), 1L))
+        .willReturn(true);
+    given(templateFileService.findByTemplateId(1L)).willReturn(nonExistFile);
+    given(templateService.findTemplateById(1L)).willReturn(template);
+
+    // then
+    assertThrows(
+        CustomException.class, () -> downloadService.downloadTemplate(1L, user, ip, device));
+  }
+
+  @Test
+  @DisplayName("파일 크기 초과 시 예외 발생")
+  void downloadTemplate_whenFileTooLarge_thenThrowException() throws IOException {
+    // given
+    Path bigFile = Files.createTempFile("big", ".zip");
+    Files.write(bigFile, new byte[11 * 1024 * 1024]); // 11MB
+
+    TemplateFile bigTemplateFile =
+        TemplateFile.builder()
+            .originalFilename("big.zip")
+            .url(bigFile.getFileName().toString())
+            .build();
+
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(user.getId(), 1L))
+        .willReturn(true);
+    given(templateFileService.findByTemplateId(1L)).willReturn(bigTemplateFile);
+    given(templateService.findTemplateById(1L)).willReturn(template);
+
+    // when & then
+    assertThrows(
+        CustomException.class, () -> downloadService.downloadTemplate(1L, user, ip, device));
+
+    Files.deleteIfExists(bigFile);
+  }
+
+  @Test
+  @DisplayName("디렉터리 이탈 경로 요청 시 예외 발생")
+  void downloadTemplate_whenInvalidPath_thenThrowException() {
+    // given
+    TemplateFile maliciousFile =
+        TemplateFile.builder().originalFilename("hack.zip").url("../../etc/passwd").build();
+
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(user.getId(), 1L))
+        .willReturn(true);
+    given(templateFileService.findByTemplateId(1L)).willReturn(maliciousFile);
+
+    // then
+    assertThrows(
+        CustomException.class, () -> downloadService.downloadTemplate(1L, user, ip, device));
+  }
+}

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplateFileServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplateFileServiceTest.java
@@ -1,0 +1,152 @@
+package com.ll.readycode.domain.templates;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.ll.readycode.domain.templates.files.entity.TemplateFile;
+import com.ll.readycode.domain.templates.files.repository.TemplateFileRepository;
+import com.ll.readycode.domain.templates.files.service.TemplateFileService;
+import com.ll.readycode.global.common.auth.oauth.properties.TemplateFileProperties;
+import com.ll.readycode.global.exception.CustomException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class TemplateFileServiceTest {
+
+  @InjectMocks private TemplateFileService templateFileService;
+
+  @Mock private TemplateFileRepository templateFileRepository;
+
+  @Mock private TemplateFileProperties properties;
+
+  @TempDir Path tempDir;
+
+  @Test
+  @DisplayName("정상적인 파일 업로드 시 TemplateFile 객체 생성")
+  void create_whenValidFile_thenReturnTemplateFile() {
+    // given
+    MultipartFile file =
+        new MockMultipartFile("file", "sample.zip", "application/zip", "hello".getBytes());
+
+    given(properties.getBaseDir()).willReturn(tempDir.toString() + "/");
+    given(properties.getMaxSize()).willReturn(DataSize.ofMegabytes(10));
+
+    // when
+    TemplateFile result = templateFileService.create(file);
+
+    // then
+    assertThat(result.getOriginalFilename()).isEqualTo("sample.zip");
+    assertThat(result.getExtension()).isEqualTo("zip");
+    assertThat(result.getUrl()).contains(".zip");
+  }
+
+  @Test
+  @DisplayName("비어있는 파일 업로드 시 예외 발생")
+  void create_whenEmptyFile_thenThrowException() {
+    // given
+    MultipartFile file = new MockMultipartFile("file", "", "application/zip", new byte[0]);
+
+    // expect
+    assertThrows(CustomException.class, () -> templateFileService.create(file));
+  }
+
+  @Test
+  @DisplayName("확장자가 없는 파일 업로드 시 예외 발생")
+  void create_whenMissingExtension_thenThrowException() {
+    MultipartFile file = new MockMultipartFile("file", "noextension", "", "abc".getBytes());
+
+    assertThrows(CustomException.class, () -> templateFileService.create(file));
+  }
+
+  @Test
+  @DisplayName("허용되지 않은 확장자 업로드 시 예외 발생")
+  void create_whenUnsupportedExtension_thenThrowException() {
+    MultipartFile file = new MockMultipartFile("file", "malware.exe", "", "virus".getBytes());
+
+    assertThrows(CustomException.class, () -> templateFileService.create(file));
+  }
+
+  @Test
+  @DisplayName("파일 용량 초과 시 예외 발생")
+  void create_whenFileSizeExceedsLimit_thenThrowException() {
+    MultipartFile file =
+        new MockMultipartFile("file", "large.zip", "application/zip", new byte[20 * 1024 * 1024]);
+    given(properties.getMaxSize()).willReturn(DataSize.ofMegabytes(10));
+
+    assertThrows(CustomException.class, () -> templateFileService.create(file));
+  }
+
+  @Test
+  @DisplayName("기존 파일 삭제 후 새 파일 저장")
+  void updateFile_whenValid_thenDeleteOldAndCreateNew() throws IOException {
+    // given
+    Path oldFilePath = Files.createFile(tempDir.resolve("old.zip"));
+    TemplateFile oldFile = TemplateFile.builder().url(oldFilePath.toString()).build();
+
+    MultipartFile newFile =
+        new MockMultipartFile("file", "new.zip", "application/zip", "new content".getBytes());
+
+    given(properties.getBaseDir()).willReturn(tempDir.toString() + "/");
+    given(properties.getMaxSize()).willReturn(DataSize.ofMegabytes(10));
+
+    // when
+    TemplateFile result = templateFileService.updateFile(oldFile, newFile);
+
+    // then
+    assertThat(result.getOriginalFilename()).isEqualTo("new.zip");
+    assertThat(Files.exists(Path.of(result.getUrl()))).isTrue();
+    assertThat(Files.exists(oldFilePath)).isFalse(); // old file should be deleted
+  }
+
+  @Test
+  @DisplayName("실제 파일 삭제 성공")
+  void deleteFile_whenFileExists_thenDeleteSuccessfully() throws IOException {
+    // given
+    Path filePath = Files.createFile(tempDir.resolve("todelete.zip"));
+    TemplateFile templateFile = TemplateFile.builder().url(filePath.toString()).build();
+
+    // when
+    templateFileService.deleteFile(templateFile);
+
+    // then
+    assertThat(Files.exists(filePath)).isFalse();
+  }
+
+  @Test
+  @DisplayName("템플릿 ID로 파일 조회 성공")
+  void findByTemplateId_whenExists_thenReturnFile() {
+    // given
+    TemplateFile file = TemplateFile.builder().id(1L).originalFilename("test.zip").build();
+    given(templateFileRepository.findByTemplateId(1L)).willReturn(Optional.of(file));
+
+    // when
+    TemplateFile result = templateFileService.findByTemplateId(1L);
+
+    // then
+    assertThat(result.getOriginalFilename()).isEqualTo("test.zip");
+  }
+
+  @Test
+  @DisplayName("템플릿 ID로 파일 조회 실패 시 예외 발생")
+  void findByTemplateId_whenNotExists_thenThrowException() {
+    // given
+    given(templateFileRepository.findByTemplateId(1L)).willReturn(Optional.empty());
+
+    // expect
+    assertThrows(CustomException.class, () -> templateFileService.findByTemplateId(1L));
+  }
+}

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplatePurchaseServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplatePurchaseServiceTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.ll.readycode.api.templates.dto.response.PurchasedTemplateResponse;
+import com.ll.readycode.domain.categories.entity.Category;
+import com.ll.readycode.domain.templates.purchases.entity.TemplatePurchase;
 import com.ll.readycode.domain.templates.purchases.repository.TemplatePurchaseRepository;
 import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
@@ -15,6 +18,8 @@ import com.ll.readycode.domain.users.userprofiles.entity.UserPurpose;
 import com.ll.readycode.domain.users.userprofiles.entity.UserRole;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,19 +39,35 @@ class TemplatePurchaseServiceTest {
   private final Long userId = 1L;
   private final Long templateId = 10L;
 
-  UserProfile user =
+  Category category1 = Category.builder().id(1L).name("백엔드").build();
+
+  UserProfile userProfile =
       UserProfile.builder()
+          .id(userId)
           .nickname("abc")
           .phoneNumber("010")
           .role(UserRole.USER)
           .purpose(UserPurpose.LEARNING)
           .build();
 
+  private Template createTemplate(int price) {
+    return Template.builder()
+        .id(templateId)
+        .title("title")
+        .description("Old")
+        .price(price)
+        .image("old.png")
+        .category(category1)
+        .createdAt(LocalDateTime.now())
+        .seller(userProfile)
+        .build();
+  }
+
   @Test
   @DisplayName("무료 템플릿 구매 성공")
   void purchaseFreeTemplate_success() {
     // given
-    Template template = Template.builder().id(templateId).price(0).build();
+    Template template = createTemplate(0);
 
     given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
         .willReturn(false);
@@ -54,30 +75,29 @@ class TemplatePurchaseServiceTest {
     given(templatePurchaseRepository.save(any())).willReturn(null);
 
     // when & then
-    assertThatCode(() -> templatePurchaseService.purchaseFreeTemplate(user, templateId))
+    assertThatCode(() -> templatePurchaseService.purchaseFreeTemplate(userProfile, templateId))
         .doesNotThrowAnyException();
   }
 
-  // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
-  /*
   @Test
   @DisplayName("이미 구매한 템플릿 예외처리")
   void purchaseFreeTemplate_fails_whenAlreadyPurchased() {
-      given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
-              .willReturn(true);
+    given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
+        .willReturn(true);
 
-      CustomException ex = assertThrows(CustomException.class,
-              () -> templatePurchaseService.purchaseFreeTemplate(user, templateId));
+    CustomException ex =
+        assertThrows(
+            CustomException.class,
+            () -> templatePurchaseService.purchaseFreeTemplate(userProfile, templateId));
 
-      assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PURCHASED);
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PURCHASED);
   }
-  */
 
   @Test
   @DisplayName("유료 템플릿을 무료 구매 API 구매시 예외처리")
   void purchaseFreeTemplate_fails_whenTemplateIsNotFree() {
     // given
-    Template paidTemplate = Template.builder().id(templateId).price(100).build();
+    Template paidTemplate = createTemplate(100);
 
     given(templatePurchaseRepository.existsByBuyerIdAndTemplateId(userId, templateId))
         .willReturn(false);
@@ -87,7 +107,7 @@ class TemplatePurchaseServiceTest {
     CustomException ex =
         assertThrows(
             CustomException.class,
-            () -> templatePurchaseService.purchaseFreeTemplate(user, templateId));
+            () -> templatePurchaseService.purchaseFreeTemplate(userProfile, templateId));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FREE_TEMPLATE);
   }
@@ -103,35 +123,23 @@ class TemplatePurchaseServiceTest {
     assertThat(result).isTrue();
   }
 
-  // TODO: UserProfile에 @SuperBuilder 적용되면 다시 테스트 활성화
-  /*
   @Test
   @DisplayName("구매한 템플릿 중 삭제된 템플릿 응답에서 제외")
   void getPurchasedTemplates_filtersOutNullTemplates() {
-      Template validTemplate = Template.builder()
-              .id(templateId)
-              .price(0)
-              .build();
+    Template validTemplate = createTemplate(0);
 
-      TemplatePurchase validPurchase = TemplatePurchase.builder()
-              .buyer(user)
-              .template(validTemplate)
-              .price(0)
-              .build();
+    TemplatePurchase validPurchase =
+        TemplatePurchase.builder().buyer(userProfile).template(validTemplate).price(0).build();
 
-      TemplatePurchase nullTemplatePurchase = TemplatePurchase.builder()
-              .buyer(user)
-              .template(null)
-              .price(0)
-              .build();
+    TemplatePurchase nullTemplatePurchase =
+        TemplatePurchase.builder().buyer(userProfile).template(null).price(0).build();
 
-      given(templatePurchaseRepository.findByBuyerIdWithTemplate(userId))
-              .willReturn(List.of(validPurchase, nullTemplatePurchase));
+    given(templatePurchaseRepository.findByBuyerIdWithTemplate(userId))
+        .willReturn(List.of(validPurchase, nullTemplatePurchase));
 
-      List<PurchasedTemplateResponse> result = templatePurchaseService.getPurchasedTemplates(userId);
+    List<PurchasedTemplateResponse> result = templatePurchaseService.getPurchasedTemplates(userId);
 
-      assertThat(result).hasSize(1);
-      assertThat(result.get(0).id()).isEqualTo(validTemplate.getId());
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).id()).isEqualTo(validTemplate.getId());
   }
-  */
 }

--- a/backend/src/test/java/com/ll/readycode/domain/templates/TemplateServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/templates/TemplateServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class TemplateServiceTest {
@@ -45,6 +46,7 @@ class TemplateServiceTest {
 
   UserProfile userProfile =
       UserProfile.builder()
+          .id(1L)
           .nickname("abc")
           .phoneNumber("010")
           .role(UserRole.USER)
@@ -92,6 +94,8 @@ class TemplateServiceTest {
   void updateTemplate_success() {
     // given
     Template existing = createTemplate(1L, "템플릿1", category1, LocalDateTime.now());
+    TemplateFile mockFile = mock(TemplateFile.class);
+    existing.setTemplateFile(mockFile);
 
     TemplateUpdateRequest request =
         new TemplateUpdateRequest("New Title", "New Desc", 200, 1L, "new.png");
@@ -101,7 +105,8 @@ class TemplateServiceTest {
 
     given(templateRepository.findById(1L)).willReturn(Optional.of(existing));
     given(categoryService.findCategoryById(1L)).willReturn(category1);
-    given(templateFileService.create(any())).willReturn(mock(TemplateFile.class));
+    given(templateFileService.updateFile(any(TemplateFile.class), any(MultipartFile.class)))
+        .willReturn(mockFile);
 
     // when
     Template result = templateService.update(1L, request, userProfile, file);
@@ -115,9 +120,11 @@ class TemplateServiceTest {
   @DisplayName("템플릿 삭제 성공")
   void deleteTemplate_success() {
     // given
-    Template template = mock(Template.class);
-    given(templateRepository.findById(1L)).willReturn(Optional.of(template));
+    Template template = createTemplate(1L, "템플릿1", category1, LocalDateTime.now());
+    TemplateFile mockFile = mock(TemplateFile.class);
+    template.setTemplateFile(mockFile);
 
+    given(templateRepository.findById(1L)).willReturn(Optional.of(template));
     doNothing().when(templateFileService).deleteFile(any());
 
     // when
@@ -125,7 +132,7 @@ class TemplateServiceTest {
 
     // then
     verify(templateRepository).delete(template);
-    verify(templateFileService).deleteFile(any());
+    verify(templateFileService).deleteFile(mockFile);
   }
 
   @Test


### PR DESCRIPTION
## 🛰 Issue Number
#26 

## 🪐 작업 내용

- [ ] TemplateFiles 도메인 및 파일 메타데이터 저장 로직 구현

- [ ] 다운로드 API 구현 (구매자만 접근 가능, 파일 응답 반환)

- [ ] 다운로드 시 기록 저장 (TemplateDownload 테이블에 IP, 기기 정보 저장)

- [ ] 템플릿 수정 시 기존 파일 삭제 후 새 파일 저장 (양방향 연관관계 처리)

- [ ] 템플릿 삭제 시 로컬 저장소의 파일도 함께 삭제 (파일 삭제 + orphanRemoval)

- [ ] 서비스 단위 테스트 및 기존 테스트 코드 보완 (lenient, temp 파일 활용 등)

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?