### PR TITLE
Be/feat/template list options

### DIFF
--- a/backend/src/main/java/com/ll/readycode/api/reviews/controller/ReviewController.java
+++ b/backend/src/main/java/com/ll/readycode/api/reviews/controller/ReviewController.java
@@ -50,8 +50,8 @@ public class ReviewController {
       @PathVariable Long templateId,
       @RequestParam(required = false) String cursor,
       @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit,
-      @RequestParam(defaultValue = "LATEST") String sort,
-      @RequestParam(defaultValue = "DESC") String order) {
+      @RequestParam(defaultValue = "latest") String sort,
+      @RequestParam(defaultValue = "desc") String order) {
     CursorPage<ReviewSummaryResponse> list =
         reviewService.getReviewList(templateId, cursor, limit, sort, order);
     return ResponseEntity.ok(SuccessResponse.of(list));

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -44,7 +44,7 @@ public class TemplateController {
       @RequestParam(defaultValue = "latest") String sort,
       @RequestParam(defaultValue = "desc") String order,
       @RequestParam(required = false) Long categoryId,
-      @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit) {
+      @RequestParam(defaultValue = "10") @Min(1) @Max(50) Integer limit) {
     TemplateScrollResponse response =
         templateService.getTemplateList(cursor, sort, order, categoryId, limit);
     return ResponseEntity.ok(SuccessResponse.of("템플릿 목록을 성공적으로 조회했습니다.", response));

--- a/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/controller/TemplateController.java
@@ -15,10 +15,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,13 +35,18 @@ public class TemplateController {
   private final TemplatePurchaseService templatePurchaseService;
   private final TemplateDownloadService templateDownloadService;
 
-  @Operation(summary = "템플릿 목록 조회", description = "템플릿을 최신순 기준으로 커서 기반 페이징 방식으로 조회합니다.")
+  @Operation(
+      summary = "템플릿 목록 조회",
+      description = "정렬(latest|rating|popular), 카테고리, 커서 기반 페이징으로 템플릿을 조회합니다.")
   @GetMapping
   public ResponseEntity<SuccessResponse<TemplateScrollResponse>> getTemplates(
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-          LocalDateTime cursor,
-      @RequestParam(defaultValue = "10") int limit) {
-    TemplateScrollResponse response = templateService.getTemplateList(cursor, limit);
+      @RequestParam(required = false) String cursor,
+      @RequestParam(defaultValue = "latest") String sort,
+      @RequestParam(defaultValue = "desc") String order,
+      @RequestParam(required = false) Long categoryId,
+      @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit) {
+    TemplateScrollResponse response =
+        templateService.getTemplateList(cursor, sort, order, categoryId, limit);
     return ResponseEntity.ok(SuccessResponse.of("템플릿 목록을 성공적으로 조회했습니다.", response));
   }
 

--- a/backend/src/main/java/com/ll/readycode/api/templates/dto/response/TemplateScrollResponse.java
+++ b/backend/src/main/java/com/ll/readycode/api/templates/dto/response/TemplateScrollResponse.java
@@ -1,11 +1,9 @@
 package com.ll.readycode.api.templates.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "커서 기반 템플릿 목록 응답")
 public record TemplateScrollResponse(
     @Schema(description = "템플릿 요약 정보 리스트") List<TemplateSummary> templates,
-    @Schema(description = "다음 페이지 요청을 위한 커서", example = "2024-12-09T15:30:00")
-        LocalDateTime nextCursor) {}
+    @Schema(description = "다음 페이지 요청을 위한 커서", example = "2024-12-09T15:30:00") String nextCursor) {}

--- a/backend/src/main/java/com/ll/readycode/domain/categories/service/CategoryService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/categories/service/CategoryService.java
@@ -57,9 +57,17 @@ public class CategoryService {
   }
 
   @Transactional(readOnly = true)
-  public Category findCategoryById(Long categoriesId) {
+  public Category findCategoryById(Long categoryId) {
     return categoryRepository
-        .findById(categoriesId)
+        .findById(categoryId)
         .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+  }
+
+  @Transactional(readOnly = true)
+  public void assertCategoryExists(Long categoryId) {
+    Boolean exist = categoryRepository.existsById(categoryId);
+    if (!exist) {
+      throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+    }
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/reviews/query/ReviewSortType.java
+++ b/backend/src/main/java/com/ll/readycode/domain/reviews/query/ReviewSortType.java
@@ -1,19 +1,19 @@
-package com.ll.readycode.domain.reviews.enums;
+package com.ll.readycode.domain.reviews.query;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum SortType {
+public enum ReviewSortType {
   LATEST("createdAt"),
   RATING("rating");
 
   private final String field;
 
-  public static SortType from(String value) {
+  public static ReviewSortType from(String value) {
     try {
-      return SortType.valueOf(value.toUpperCase());
+      return ReviewSortType.valueOf(value.toUpperCase());
     } catch (IllegalArgumentException e) {
       return LATEST; // 기본값
     }

--- a/backend/src/main/java/com/ll/readycode/domain/reviews/reader/ReviewReader.java
+++ b/backend/src/main/java/com/ll/readycode/domain/reviews/reader/ReviewReader.java
@@ -1,9 +1,9 @@
 package com.ll.readycode.domain.reviews.reader;
 
 import com.ll.readycode.domain.reviews.entity.Review;
-import com.ll.readycode.domain.reviews.enums.OrderType;
-import com.ll.readycode.domain.reviews.enums.SortType;
+import com.ll.readycode.domain.reviews.query.ReviewSortType;
 import com.ll.readycode.domain.reviews.repository.ReviewRepository;
+import com.ll.readycode.global.common.types.OrderType;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
 import java.util.List;
@@ -38,8 +38,12 @@ public class ReviewReader {
 
   // 템플릿별 리뷰 목록 조회
   public List<Review> findByTemplateWithCursor(
-      Long templateId, String cursor, int limit, SortType sortType, OrderType orderType) {
+      Long templateId,
+      String cursor,
+      int limit,
+      ReviewSortType reviewSortType,
+      OrderType orderType) {
     return reviewRepository.findByTemplateWithCursor(
-        templateId, cursor, limit, sortType, orderType);
+        templateId, cursor, limit, reviewSortType, orderType);
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/reviews/repository/ReviewRepositoryCustom.java
+++ b/backend/src/main/java/com/ll/readycode/domain/reviews/repository/ReviewRepositoryCustom.java
@@ -1,8 +1,8 @@
 package com.ll.readycode.domain.reviews.repository;
 
 import com.ll.readycode.domain.reviews.entity.Review;
-import com.ll.readycode.domain.reviews.enums.OrderType;
-import com.ll.readycode.domain.reviews.enums.SortType;
+import com.ll.readycode.domain.reviews.query.ReviewSortType;
+import com.ll.readycode.global.common.types.OrderType;
 import java.util.List;
 import java.util.Set;
 
@@ -10,5 +10,9 @@ public interface ReviewRepositoryCustom {
   Set<Long> findTemplateIdsWithReviewByUser(Long userId, Set<Long> templateIds);
 
   List<Review> findByTemplateWithCursor(
-      Long templateId, String cursor, int limit, SortType sortType, OrderType orderType);
+      Long templateId,
+      String cursor,
+      int limit,
+      ReviewSortType reviewSortType,
+      OrderType orderType);
 }

--- a/backend/src/main/java/com/ll/readycode/domain/reviews/service/ReviewService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/reviews/service/ReviewService.java
@@ -34,7 +34,7 @@ public class ReviewService {
   @Transactional
   public ReviewResponse createReview(Long templateId, UserProfile user, ReviewCreateRequest req) {
     Template template = templateService.findTemplateById(templateId);
-    templatePurchaseService.validatePurchasedOrThrow(user.getId(), templateId);
+    templatePurchaseService.throwIfNotPurchased(user.getId(), templateId);
 
     validateNotAlreadyReviewed(user.getId(), templateId);
 

--- a/backend/src/main/java/com/ll/readycode/domain/reviews/service/ReviewService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/reviews/service/ReviewService.java
@@ -13,6 +13,7 @@ import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseServi
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.service.TemplateService;
 import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.common.pagination.PaginationPolicy;
 import com.ll.readycode.global.common.types.OrderType;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
@@ -57,7 +58,7 @@ public class ReviewService {
       Long templateId, String cursor, Integer limit, String sort, String order) {
     ReviewSortType reviewSortType = ReviewSortType.from(sort);
     OrderType orderType = OrderType.from(order);
-    int pageSize = (limit == null) ? 10 : Math.min(Math.max(limit, 1), 50);
+    int pageSize = PaginationPolicy.clamp(limit);
 
     List<Review> rows =
         reviewReader.findByTemplateWithCursor(

--- a/backend/src/main/java/com/ll/readycode/domain/reviews/service/ReviewService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/reviews/service/ReviewService.java
@@ -6,14 +6,14 @@ import com.ll.readycode.api.reviews.dto.response.CursorPage;
 import com.ll.readycode.api.reviews.dto.response.ReviewResponse;
 import com.ll.readycode.api.reviews.dto.response.ReviewSummaryResponse;
 import com.ll.readycode.domain.reviews.entity.Review;
-import com.ll.readycode.domain.reviews.enums.OrderType;
-import com.ll.readycode.domain.reviews.enums.SortType;
+import com.ll.readycode.domain.reviews.query.ReviewSortType;
 import com.ll.readycode.domain.reviews.reader.ReviewReader;
 import com.ll.readycode.domain.reviews.repository.ReviewRepository;
 import com.ll.readycode.domain.templates.purchases.service.TemplatePurchaseService;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.domain.templates.templates.service.TemplateService;
 import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
+import com.ll.readycode.global.common.types.OrderType;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
 import java.math.BigDecimal;
@@ -55,18 +55,18 @@ public class ReviewService {
   @Transactional(readOnly = true)
   public CursorPage<ReviewSummaryResponse> getReviewList(
       Long templateId, String cursor, Integer limit, String sort, String order) {
-    SortType sortType = SortType.from(sort);
+    ReviewSortType reviewSortType = ReviewSortType.from(sort);
     OrderType orderType = OrderType.from(order);
     int pageSize = (limit == null) ? 10 : Math.min(Math.max(limit, 1), 50);
 
     List<Review> rows =
         reviewReader.findByTemplateWithCursor(
-            templateId, cursor, pageSize + 1, sortType, orderType);
+            templateId, cursor, pageSize + 1, reviewSortType, orderType);
 
     boolean hasNext = rows.size() > pageSize;
     if (hasNext) rows = rows.subList(0, pageSize);
 
-    String nextCursor = hasNext ? encodeCursor(rows.get(rows.size() - 1), sortType) : null;
+    String nextCursor = hasNext ? encodeCursor(rows.get(rows.size() - 1), reviewSortType) : null;
 
     List<ReviewSummaryResponse> items = rows.stream().map(ReviewSummaryResponse::of).toList();
 
@@ -107,8 +107,8 @@ public class ReviewService {
     }
   }
 
-  private String encodeCursor(Review r, SortType sortType) {
-    if (sortType == SortType.RATING) {
+  private String encodeCursor(Review r, ReviewSortType reviewSortType) {
+    if (reviewSortType == ReviewSortType.RATING) {
       return r.getRating().toPlainString() + "|" + r.getId();
     }
     return r.getCreatedAt() + "|" + r.getId();

--- a/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/purchases/service/TemplatePurchaseService.java
@@ -46,6 +46,8 @@ public class TemplatePurchaseService {
 
     try {
       templatePurchaseRepository.save(templatePurchase);
+      templatePurchaseRepository.flush();
+      templateService.incrementPurchaseCount(templateId);
     } catch (DataIntegrityViolationException e) {
       throw new CustomException(ErrorCode.ALREADY_PURCHASED);
     }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/query/TemplateSortType.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/query/TemplateSortType.java
@@ -1,0 +1,22 @@
+package com.ll.readycode.domain.templates.query;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TemplateSortType {
+  LATEST("createAt"),
+  RATING("rating"),
+  POPULAR("popular");
+
+  private final String field;
+
+  public static TemplateSortType from(String value) {
+    try {
+      return TemplateSortType.valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return LATEST;
+    }
+  }
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/query/TemplateSortType.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/query/TemplateSortType.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum TemplateSortType {
-  LATEST("createAt"),
+  LATEST("createdAt"),
   RATING("rating"),
   POPULAR("popular");
 

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/entity/Template.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/entity/Template.java
@@ -10,6 +10,7 @@ import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -47,14 +48,21 @@ public class Template extends BaseEntity {
       fetch = FetchType.LAZY)
   private TemplateFile templateFile;
 
+  @Builder.Default
   @Column(nullable = false)
   private long reviewCount = 0L;
 
+  @Builder.Default
   @Column(nullable = false)
   private long ratingSum = 0L; // 별점×10 누적합
 
+  @Builder.Default
   @Column(nullable = false, precision = 3, scale = 2)
   private BigDecimal avgRating = new BigDecimal("0.00"); // 표시/정렬용 0.00~5.00
+
+  @Builder.Default
+  @Column(name = "purchase_count", nullable = false)
+  private Long purchaseCount = 0L;
 
   @Version private Long version;
 
@@ -97,5 +105,9 @@ public class Template extends BaseEntity {
     // (ratingSum / 10.0) / reviewCount  → 소수 2자리 반올림
     BigDecimal sum = BigDecimal.valueOf(ratingSum).divide(BigDecimal.TEN);
     this.avgRating = sum.divide(BigDecimal.valueOf(reviewCount), 2, RoundingMode.HALF_UP);
+  }
+
+  public void incrementPurchaseCount() {
+    this.purchaseCount++;
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepository.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepository.java
@@ -2,8 +2,17 @@ package com.ll.readycode.domain.templates.templates.repository;
 
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface TemplateRepository
-    extends JpaRepository<Template, Long>, TemplateRepositoryCustom {}
+    extends JpaRepository<Template, Long>, TemplateRepositoryCustom {
+  @Modifying
+  @Transactional
+  @Query("UPDATE Template t SET t.purchaseCount = t.purchaseCount + 1 WHERE t.id = :id")
+  int incrementPurchaseCount(@Param("id") Long templateId);
+}

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepositoryCustom.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.ll.readycode.domain.templates.templates.repository;
 
+import com.ll.readycode.domain.templates.query.TemplateSortType;
 import com.ll.readycode.domain.templates.templates.entity.Template;
-import java.time.LocalDateTime;
+import com.ll.readycode.global.common.types.OrderType;
+
 import java.util.List;
 
 public interface TemplateRepositoryCustom {
-  List<Template> findScrollTemplates(LocalDateTime cursor, int limit);
+  List<Template> findScrollTemplates(
+      String cursor, TemplateSortType sortType, OrderType orderType, Long categoryId, int limit);
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepositoryImpl.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepositoryImpl.java
@@ -4,7 +4,13 @@ import com.ll.readycode.domain.templates.query.TemplateSortType;
 import com.ll.readycode.domain.templates.templates.entity.QTemplate;
 import com.ll.readycode.domain.templates.templates.entity.Template;
 import com.ll.readycode.global.common.types.OrderType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -15,16 +21,146 @@ public class TemplateRepositoryImpl implements TemplateRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
+  public record Latest(LocalDateTime ts, Long id) {}
+
+  public record Rating(BigDecimal rating, LocalDateTime ts, Long id) {}
+
+  public record Popular(Long purchaseCount, LocalDateTime ts, Long id) {}
+
+  private static final int RATING_CURSOR_PARTS = 3;
+  private static final int POPULAR_CURSOR_PARTS = 3;
+  private static final int LATEST_CURSOR_PARTS = 2;
+
   @Override
   public List<Template> findScrollTemplates(
       String cursor, TemplateSortType sortType, OrderType orderType, Long categoryId, int limit) {
-    QTemplate template = QTemplate.template;
+    QTemplate t = QTemplate.template;
+    BooleanBuilder where = new BooleanBuilder();
 
-    return queryFactory
-        .selectFrom(template)
-        .where(cursor != null ? template.createdAt.lt(cursor) : null)
-        .orderBy(template.createdAt.desc())
-        .limit(limit)
-        .fetch();
+    if (categoryId != null) {
+      where.and(t.category.id.eq(categoryId));
+    }
+
+    boolean desc = (orderType == OrderType.DESC);
+
+    switch (sortType) {
+      case LATEST -> applyLatestCursor(where, t, cursor, desc);
+      case RATING -> applyRatingCursor(where, t, cursor, desc);
+      case POPULAR -> applyPopularCursor(where, t, cursor, desc);
+    }
+
+    OrderSpecifier<?>[] orders = buildOrders(t, sortType, desc);
+
+    return queryFactory.selectFrom(t).where(where).orderBy(orders).limit(limit).fetch();
+  }
+
+  private Latest decodeLatest(String cursor) {
+    if (cursor == null) return null;
+    String[] parts = cursor.split("\\|");
+    if (parts.length != LATEST_CURSOR_PARTS) return null;
+
+    try {
+      LocalDateTime ts = LocalDateTime.parse(parts[0]);
+      Long id = Long.parseLong(parts[1]);
+      return new Latest(ts, id);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private void applyLatestCursor(BooleanBuilder where, QTemplate t, String cursor, boolean desc) {
+    Latest key = decodeLatest(cursor);
+    if (key == null) return;
+
+    BooleanExpression edge = desc ? t.createdAt.lt(key.ts()) : t.createdAt.gt(key.ts());
+    BooleanExpression tie =
+        t.createdAt.eq(key.ts()).and(desc ? t.id.lt(key.id()) : t.id.gt(key.id()));
+
+    where.and(edge.or(tie));
+  }
+
+  private Rating decodeRating(String cursor) {
+    if (cursor == null) return null;
+    String[] parts = cursor.split("\\|");
+    if (parts.length != RATING_CURSOR_PARTS) return null;
+
+    try {
+      BigDecimal rating = new BigDecimal(parts[0]);
+      LocalDateTime ts = LocalDateTime.parse(parts[1]);
+      Long id = Long.parseLong(parts[2]);
+      return new Rating(rating, ts, id);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private void applyRatingCursor(BooleanBuilder where, QTemplate t, String cursor, boolean desc) {
+    Rating key = decodeRating(cursor);
+    if (key == null) return;
+
+    NumberExpression<BigDecimal> r = t.avgRating.coalesce(BigDecimal.ZERO);
+    BooleanExpression edge = desc ? r.lt(key.rating()) : r.gt(key.rating());
+    BooleanExpression tie1 =
+        r.eq(key.rating()).and(desc ? t.createdAt.lt(key.ts()) : t.createdAt.gt(key.ts()));
+    BooleanExpression tie2 =
+        r.eq(key.rating())
+            .and(t.createdAt.eq(key.ts()))
+            .and(desc ? t.id.lt(key.id()) : t.id.gt(key.id()));
+
+    where.and(edge.or(tie1).or(tie2));
+  }
+
+  private Popular decodePopular(String cursor) {
+    if (cursor == null) return null;
+    String[] parts = cursor.split("\\|");
+    if (parts.length != POPULAR_CURSOR_PARTS) return null;
+
+    try {
+      Long purchase = Long.parseLong(parts[0]);
+      LocalDateTime ts = LocalDateTime.parse(parts[1]);
+      Long id = Long.parseLong(parts[2]);
+      return new Popular(purchase, ts, id);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private void applyPopularCursor(BooleanBuilder where, QTemplate t, String cursor, boolean desc) {
+    Popular key = decodePopular(cursor);
+    if (key == null) return;
+
+    BooleanExpression edge =
+        desc ? t.purchaseCount.lt(key.purchaseCount()) : t.purchaseCount.gt(key.purchaseCount());
+    BooleanExpression tie1 =
+        t.purchaseCount
+            .eq(key.purchaseCount())
+            .and(desc ? t.createdAt.lt(key.ts()) : t.createdAt.gt(key.ts()));
+    BooleanExpression tie2 =
+        t.purchaseCount
+            .eq(key.purchaseCount())
+            .and(t.createdAt.eq(key.ts()))
+            .and(desc ? t.id.lt(key.id()) : t.id.gt(key.id()));
+
+    where.and(edge.or(tie1).or(tie2));
+  }
+
+  private OrderSpecifier<?>[] buildOrders(QTemplate t, TemplateSortType sortType, boolean desc) {
+    switch (sortType) {
+      case RATING:
+        // avgRating 필드가 있을 때만 활성화
+        return desc
+            ? new OrderSpecifier<?>[] {t.avgRating.desc(), t.createdAt.desc(), t.id.desc()}
+            : new OrderSpecifier<?>[] {t.avgRating.asc(), t.createdAt.asc(), t.id.asc()};
+      case POPULAR:
+        // purchaseCount 필드가 있을 때만 활성화
+        return desc
+            ? new OrderSpecifier<?>[] {t.purchaseCount.desc(), t.createdAt.desc(), t.id.desc()}
+            : new OrderSpecifier<?>[] {t.purchaseCount.asc(), t.createdAt.asc(), t.id.asc()};
+      case LATEST:
+      default:
+        return desc
+            ? new OrderSpecifier<?>[] {t.createdAt.desc(), t.id.desc()}
+            : new OrderSpecifier<?>[] {t.createdAt.asc(), t.id.asc()};
+    }
   }
 }

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepositoryImpl.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/repository/TemplateRepositoryImpl.java
@@ -1,9 +1,10 @@
 package com.ll.readycode.domain.templates.templates.repository;
 
+import com.ll.readycode.domain.templates.query.TemplateSortType;
 import com.ll.readycode.domain.templates.templates.entity.QTemplate;
 import com.ll.readycode.domain.templates.templates.entity.Template;
+import com.ll.readycode.global.common.types.OrderType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -15,7 +16,8 @@ public class TemplateRepositoryImpl implements TemplateRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public List<Template> findScrollTemplates(LocalDateTime cursor, int limit) {
+  public List<Template> findScrollTemplates(
+      String cursor, TemplateSortType sortType, OrderType orderType, Long categoryId, int limit) {
     QTemplate template = QTemplate.template;
 
     return queryFactory

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
@@ -146,6 +146,11 @@ public class TemplateService {
         .orElseThrow(() -> new CustomException(ErrorCode.TEMPLATE_NOT_FOUND));
   }
 
+  @Transactional
+  public void incrementPurchaseCount(Long templateId) {
+    templateRepository.incrementPurchaseCount(templateId);
+  }
+
   private void validateTemplateOwner(Template template, Long userId) {
     if (!template.getSeller().getId().equals(userId)) {
       throw new CustomException(ErrorCode.TEMPLATE_ACCESS_DENIED);

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
@@ -1,6 +1,5 @@
 package com.ll.readycode.domain.templates.templates.service;
 
-
 import com.ll.readycode.api.templates.dto.request.TemplateCreateRequest;
 import com.ll.readycode.api.templates.dto.request.TemplateUpdateRequest;
 import com.ll.readycode.api.templates.dto.response.TemplateScrollResponse;
@@ -101,8 +100,7 @@ public class TemplateService {
         templateRepository.findScrollTemplates(cursor, sortType, orderType, categoryId, pageSize);
 
     // TODO: nextCursor 수정 => createdAt|id
-    String nextCursor =
-        templates.isEmpty() ? null : templates.get(templates.size() - 1).getCreatedAt();
+    String nextCursor = "";
 
     List<TemplateSummary> result = templates.stream().map(TemplateSummary::from).toList();
 

--- a/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/ll/readycode/domain/templates/templates/service/TemplateService.java
@@ -82,7 +82,9 @@ public class TemplateService {
     templateRepository.delete(template);
   }
 
-  public TemplateScrollResponse getTemplateList(LocalDateTime cursor, int limit) {
+  public TemplateScrollResponse getTemplateList(
+      String cursor, String sort, String order, Long categoryId, int limit) {
+
     List<Template> templates = templateRepository.findScrollTemplates(cursor, limit);
 
     LocalDateTime nextCursor =

--- a/backend/src/main/java/com/ll/readycode/global/common/pagination/PaginationPolicy.java
+++ b/backend/src/main/java/com/ll/readycode/global/common/pagination/PaginationPolicy.java
@@ -1,0 +1,14 @@
+package com.ll.readycode.global.common.pagination;
+
+public final class PaginationPolicy {
+  public static final int DEFAULT_LIMIT = 10;
+  public static final int MIN_LIMIT = 1;
+  public static final int MAX_LIMIT = 50;
+
+  private PaginationPolicy() {}
+
+  public static int clamp(Integer limit) {
+    int v = (limit == null) ? DEFAULT_LIMIT : limit;
+    return Math.max(MIN_LIMIT, Math.min(MAX_LIMIT, v));
+  }
+}

--- a/backend/src/main/java/com/ll/readycode/global/common/types/OrderType.java
+++ b/backend/src/main/java/com/ll/readycode/global/common/types/OrderType.java
@@ -1,4 +1,4 @@
-package com.ll.readycode.domain.reviews.enums;
+package com.ll.readycode.global.common.types;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ll/readycode/global/exception/ErrorCode.java
@@ -39,7 +39,6 @@ public enum ErrorCode {
   TEMPLATE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "T003", "템플릿 업로드에 실패했습니다."),
   INVALID_TEMPLATE_META(HttpStatus.BAD_REQUEST, "T004", "템플릿 메타 정보가 유효하지 않습니다."),
   TEMPLATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "T005", "템플릿에 대한 수정 권한이 없습니다."),
-  TEMPLATE_FORBIDDEN(HttpStatus.FORBIDDEN, "T006", "템플릿에 대한 접근이 거부되었습니다."),
 
   // 템플릿 구매 (TemplatePurchase)
   ALREADY_PURCHASED(HttpStatus.CONFLICT, "TP001", "이미 구매한 템플릿입니다."),

--- a/backend/src/test/java/com/ll/readycode/domain/reviews/ReviewServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/reviews/ReviewServiceTest.java
@@ -86,7 +86,7 @@ class ReviewServiceTest {
     ReviewCreateRequest req = new ReviewCreateRequest("굿", new BigDecimal("4.5"));
 
     given(templateService.findTemplateById(templateId)).willReturn(t);
-    willDoNothing().given(templatePurchaseService).validatePurchasedOrThrow(u.getId(), templateId);
+    willDoNothing().given(templatePurchaseService).throwIfNotPurchased(u.getId(), templateId);
     given(reviewReader.existsByUserAndTemplate(u.getId(), templateId)).willReturn(false);
 
     // save 시 아이디 채워서 반환
@@ -124,7 +124,7 @@ class ReviewServiceTest {
     ReviewCreateRequest req = new ReviewCreateRequest("굿", new BigDecimal("4.0"));
 
     given(templateService.findTemplateById(templateId)).willReturn(t);
-    willDoNothing().given(templatePurchaseService).validatePurchasedOrThrow(u.getId(), templateId);
+    willDoNothing().given(templatePurchaseService).throwIfNotPurchased(u.getId(), templateId);
     given(reviewReader.existsByUserAndTemplate(u.getId(), templateId)).willReturn(true);
 
     assertThatThrownBy(() -> reviewService.createReview(templateId, u, req))

--- a/backend/src/test/java/com/ll/readycode/domain/reviews/ReviewServiceTest.java
+++ b/backend/src/test/java/com/ll/readycode/domain/reviews/ReviewServiceTest.java
@@ -10,8 +10,7 @@ import com.ll.readycode.api.reviews.dto.response.CursorPage;
 import com.ll.readycode.api.reviews.dto.response.ReviewResponse;
 import com.ll.readycode.api.reviews.dto.response.ReviewSummaryResponse;
 import com.ll.readycode.domain.reviews.entity.Review;
-import com.ll.readycode.domain.reviews.enums.OrderType;
-import com.ll.readycode.domain.reviews.enums.SortType;
+import com.ll.readycode.domain.reviews.query.ReviewSortType;
 import com.ll.readycode.domain.reviews.reader.ReviewReader;
 import com.ll.readycode.domain.reviews.repository.ReviewRepository;
 import com.ll.readycode.domain.reviews.service.ReviewService;
@@ -21,6 +20,7 @@ import com.ll.readycode.domain.templates.templates.service.TemplateService;
 import com.ll.readycode.domain.users.userprofiles.entity.UserProfile;
 import com.ll.readycode.domain.users.userprofiles.entity.UserPurpose;
 import com.ll.readycode.domain.users.userprofiles.entity.UserRole;
+import com.ll.readycode.global.common.types.OrderType;
 import com.ll.readycode.global.exception.CustomException;
 import com.ll.readycode.global.exception.ErrorCode;
 import java.math.BigDecimal;
@@ -198,7 +198,7 @@ class ReviewServiceTest {
   @DisplayName("리뷰 목록 조회: hasNext 계산 및 커서 인코딩(RATING 정렬)")
   void getReviewList_withCursor_rating() {
     long templateId = 10L;
-    SortType sortType = SortType.RATING;
+    ReviewSortType reviewSortType = ReviewSortType.RATING;
     OrderType orderType = OrderType.DESC;
     int pageSize = 2;
 
@@ -212,7 +212,7 @@ class ReviewServiceTest {
 
     given(
             reviewReader.findByTemplateWithCursor(
-                eq(templateId), isNull(), eq(pageSize + 1), eq(sortType), eq(orderType)))
+                eq(templateId), isNull(), eq(pageSize + 1), eq(reviewSortType), eq(orderType)))
         .willReturn(List.of(r1, r2, r3));
 
     CursorPage<ReviewSummaryResponse> page =
@@ -240,7 +240,7 @@ class ReviewServiceTest {
                 eq(templateId),
                 isNull(),
                 eq(pageSize + 1),
-                eq(SortType.RATING),
+                eq(ReviewSortType.RATING),
                 eq(OrderType.DESC)))
         .willReturn(List.of(r1, r2)); // 초과분 없음
 


### PR DESCRIPTION
## 🛰 Issue Number
#36 

## 🪐 작업 내용
- 템플릿 목록 조회 커서 확장

- 정렬: 최신(createdAt), 별점(rating), 인기(purchaseCount)

- 커서: <sortKey>|<id> → 동일 키 시 id로 2차 정렬

- ASC/DESC 지원, 잘못된 파라미터 예외 처리

- 카테고리 필터 지원

- QueryDSL (sortKey, id) 튜플 비교 + fetch join

- Template 엔티티 개선

- purchaseCount 필드 추가 (기본값 0)

- 구매 완료 시 incrementPurchaseCount() 호출

- 중복 구매 및 동시성 예외 처리

- 테스트 보강

- 커서 경계값, 동일 키 다건, ASC/DESC

- rating/popular 정렬 검증

- 잘못된 파라미터 예외

- 구매 시 purchaseCount 증가/중복 시 미증가 확인

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?